### PR TITLE
CUR-598 - Updated API endpoint for fetching own canvas courses.

### DIFF
--- a/app/CurrikiGo/Canvas/Commands/GetCoursesCommand.php
+++ b/app/CurrikiGo/Canvas/Commands/GetCoursesCommand.php
@@ -62,8 +62,11 @@ class GetCoursesCommand implements Command
     {
         $response = null;
         try {
-            $url = $this->apiURL . '/accounts/' . $this->accountId . '/courses';
-            $url .= $this->programName ? '?search_term=' . $this->programName : '';
+            //$url = $this->apiURL . '/accounts/' . $this->accountId . '/courses';
+            //$url .= $this->programName ? '?search_term=' . $this->programName : '';
+            //$url = $this->apiURL . '/users/' . $this->accountId . '/courses';
+            $url = $this->apiURL . '/courses';
+            $url .= '?enrollment_state=active';
             $response = $this->httpClient->request('GET', $url, [
                     'headers' => ['Authorization' => "Bearer {$this->accessToken}", 'Accept' => 'application/json']
                 ])->getBody()->getContents();


### PR DESCRIPTION
We've changed the api end point for fetching courses to the one that is accessible using a teacher's access token.
The old one was only accessible to an admin level access token.