### PR TITLE
feature/CUR-623-update-elasticsearch-for-project-status-change

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -67,7 +67,7 @@ class SearchController extends Controller
     /**
      * Advance search
      *
-     * Advance search for projects, playlists and activities having isPublic and elasticsearch set to true
+     * Advance search for projects, playlists and activities having indexing approved
      *
      * @queryParam query required Query to search. Example: test
      * @queryParam negativeQuery Terms that should not exist. Example: badword
@@ -99,8 +99,7 @@ class SearchController extends Controller
     public function advance(SearchRequest $searchRequest)
     {
         $data = $searchRequest->validated();
-        $data['isPublic'] = true;
-        $data['elasticsearch'] = true;
+        $data['indexing'] = [3];
 
         $results = $this->activityRepository->advanceSearchForm($data);
 
@@ -110,12 +109,11 @@ class SearchController extends Controller
     /**
      * Dashboard search
      *
-     * Dashboard search for projects, playlists and activities irrespective of isPublic and elasticsearch status
+     * Dashboard search for projects, playlists and activities irrespective of indexing status
      *
      * @queryParam  query required Query to search. Example: test
      * @queryParam  negativeQuery Terms that should not exist. Example: badword
-     * @queryParam  isPublic Public access enabled or disabled. Example: 1
-     * @queryParam  elasticsearch Elasticsearch enabled or disabled. Example: 0
+     * @queryParam  indexing Indexing requested, approved or not approved. Example: [3]
      * @queryParam  startDate Start date for search by date range. Example: 2020-04-30 00:00:00
      * @queryParam  endDate End date for search by date range. Example: 2020-04-30 23:59:59
      * @queryParam  subjectIds Array of subject ids to match. Example: ['ComputerScience']

--- a/app/Http/Requests/V1/SearchRequest.php
+++ b/app/Http/Requests/V1/SearchRequest.php
@@ -26,8 +26,7 @@ class SearchRequest extends FormRequest
         return [
             'query' => 'required|string|max:255',
             'negativeQuery' => 'string|max:255',
-            'isPublic' => 'boolean',
-            'elasticsearch' => 'boolean',
+            'indexing' => 'array|in:null,1,2,3',
             'startDate' => 'date',
             'endDate' => 'date',
             'userIds' => 'array|exists:App\User,id',

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -47,14 +47,16 @@ class Activity extends Model
             'h5p_content_id' => $this->h5p_content_id,
             'subject_id' => $this->subject_id,
             'education_level_id' => $this->education_level_id,
-            'is_public' => $this->is_public,
-            'elasticsearch' => $this->elasticsearch,
             'created_at' => $this->created_at ? $this->created_at->toAtomString() : null,
             'updated_at' => $this->updated_at ? $this->updated_at->toAtomString() : null
         ];
 
         if ($this->playlist) {
             $searchableArray['project_id'] = $this->playlist->project_id;
+
+            if ($this->playlist->project) {
+                $searchableArray['indexing'] = $this->playlist->project->indexing;
+            }
         }
 
         $activityRepository = resolve(ActivityRepositoryInterface::class);

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -32,14 +32,12 @@ class Playlist extends Model
         $searchableArray = [
             'title' => $this->title,
             'project_id' => $this->project_id,
-            'is_public' => $this->is_public,
-            'elasticsearch' => $this->elasticsearch,
             'created_at' => $this->created_at ? $this->created_at->toAtomString() : null,
             'updated_at' => $this->updated_at ? $this->updated_at->toAtomString() : null
         ];
 
         if ($this->project) {
-            $searchableArray['shared'] = $this->project->shared;
+            $searchableArray['indexing'] = $this->project->indexing;
         }
 
         return $searchableArray;

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -48,8 +48,7 @@ class Project extends Model
             'project_id' => $this->id,
             'name' => $this->name,
             'description' => $this->description,
-            'is_public' => $this->is_public,
-            'elasticsearch' => $this->elasticsearch,
+            'indexing' => $this->indexing,
             'created_at' => $this->created_at ? $this->created_at->toAtomString() : '',
             'updated_at' => $this->updated_at ? $this->updated_at->toAtomString() : ''
         ];

--- a/app/Repositories/Activity/ActivityRepository.php
+++ b/app/Repositories/Activity/ActivityRepository.php
@@ -65,8 +65,7 @@ class ActivityRepository extends BaseRepository implements ActivityRepositoryInt
         $searchedModels = $this->model->searchForm()
             ->query(Arr::get($data, 'query', 0))
             ->join(Project::class, Playlist::class)
-            ->isPublic(true)
-            ->elasticsearch(true)
+            ->indexing([3])
             ->sort(Arr::get($data, 'sort', '_id'), Arr::get($data, 'order', 'desc'))
             ->from(Arr::get($data, 'from', 0))
             ->size(Arr::get($data, 'size', 10))
@@ -144,6 +143,7 @@ class ActivityRepository extends BaseRepository implements ActivityRepositoryInt
             ->type(Arr::get($data, 'type', 0))
             ->startDate(Arr::get($data, 'startDate', 0))
             ->endDate(Arr::get($data, 'endDate', 0))
+            ->indexing(Arr::get($data, 'indexing', []))
             ->subjectIds(Arr::get($data, 'subjectIds', []))
             ->educationLevelIds(Arr::get($data, 'educationLevelIds', []))
             ->projectIds($projectIds)
@@ -155,14 +155,6 @@ class ActivityRepository extends BaseRepository implements ActivityRepositoryInt
 
         if (isset($data['model']) && !empty($data['model'])) {
             $searchResultQuery = $searchResultQuery->postFilter('term', ['_index' => $data['model']]);
-        }
-
-        if (isset($data['isPublic']) && is_bool($data['isPublic'])) {
-            $searchResultQuery = $searchResultQuery->isPublic($data['isPublic']);
-        }
-
-        if (isset($data['elasticsearch']) && is_bool($data['elasticsearch'])) {
-            $searchResultQuery = $searchResultQuery->elasticsearch($data['elasticsearch']);
         }
 
         $searchResult = $searchResultQuery->execute();

--- a/elastic/migrations/2020_08_25_084234_create_activities_index.php
+++ b/elastic/migrations/2020_08_25_084234_create_activities_index.php
@@ -23,8 +23,7 @@ final class CreateActivitiesIndex implements MigrationInterface
             $mapping->keyword('h5p_content_id');
             $mapping->keyword('subject_id');
             $mapping->keyword('education_level_id');
-            $mapping->boolean('is_public');
-            $mapping->boolean('elasticsearch');
+            $mapping->keyword('indexing');
             $mapping->date('created_at');
             $mapping->date('updated_at');
             $mapping->keyword('project_id');

--- a/elastic/migrations/2020_08_25_084243_create_playlists_index.php
+++ b/elastic/migrations/2020_08_25_084243_create_playlists_index.php
@@ -17,8 +17,7 @@ final class CreatePlaylistsIndex implements MigrationInterface
         Index::create('playlists', function (Mapping $mapping, Settings $settings) {
             $mapping->text('title');
             $mapping->keyword('project_id');
-            $mapping->boolean('is_public');
-            $mapping->boolean('elasticsearch');
+            $mapping->keyword('indexing');
             $mapping->date('created_at');
             $mapping->date('updated_at');
         });

--- a/elastic/migrations/2020_08_25_084255_create_projects_index.php
+++ b/elastic/migrations/2020_08_25_084255_create_projects_index.php
@@ -18,8 +18,7 @@ final class CreateProjectsIndex implements MigrationInterface
             $mapping->keyword('project_id');
             $mapping->text('name');
             $mapping->text('description');
-            $mapping->boolean('is_public');
-            $mapping->boolean('elasticsearch');
+            $mapping->keyword('indexing');
             $mapping->date('created_at');
             $mapping->date('updated_at');
         });


### PR DESCRIPTION
Removed "isPublic" and "elasticsearch" fields in Elasticsearch for projects, playlists and activities.
Added and populated "indexing" field in Elasticsearch for projects, playlists and activities.
Updated advanced, dashboard and deep linking search APIs accordingly.