### PR TITLE
Removed curl requests for activities cloning

### DIFF
--- a/app/Jobs/CloneActivity.php
+++ b/app/Jobs/CloneActivity.php
@@ -56,17 +56,17 @@ class CloneActivity implements ShouldQueue
      */
     public function handle(ActivityRepositoryInterface $activityRepository, UserRepositoryInterface $userRepository)
     {
-        try{
+        try {
             $activityRepository->clone($this->playlist, $this->activity, $this->token);
             $isDuplicate = ($this->activity->playlist_id == $this->playlist->id);
             $process = ($isDuplicate) ? "duplicate" : "clone";
-            $message =  "Your request to $process activity [".$this->activity->title."] has been completed and available" ;
+            $message = "Your request to $process activity [" . $this->activity->title . "] has been completed and available";
             (new \App\Events\SendMessage($message));
             $user_id = $userRepository->parseToken($this->token);
             $user = User::find($user_id);
             $userName = rtrim($user->first_name . ' ' . $user->last_name, ' ');
             $user->notify(new CloneNotification($message, $process, $userName));
-        }catch(\Exception $e){
+        } catch (\Exception $e) {
             Log::error($e->getMessage());
         }
     }

--- a/app/Jobs/CloneActivity.php
+++ b/app/Jobs/CloneActivity.php
@@ -56,14 +56,18 @@ class CloneActivity implements ShouldQueue
      */
     public function handle(ActivityRepositoryInterface $activityRepository, UserRepositoryInterface $userRepository)
     {
-        $activityRepository->clone($this->playlist, $this->activity, $this->token);
-        $isDuplicate = ($this->activity->playlist_id == $this->playlist->id);
-        $process = ($isDuplicate) ? "duplicate" : "clone";
-        $message =  "Your request to $process activity [".$this->activity->title."] has been completed and available" ;
-        (new \App\Events\SendMessage($message));
-        $user_id = $userRepository->parseToken($this->token);
-        $user = User::find($user_id);
-        $userName = rtrim($user->first_name . ' ' . $user->last_name, ' ');
-        $user->notify(new CloneNotification($message, $process, $userName));
+        try{
+            $activityRepository->clone($this->playlist, $this->activity, $this->token);
+            $isDuplicate = ($this->activity->playlist_id == $this->playlist->id);
+            $process = ($isDuplicate) ? "duplicate" : "clone";
+            $message =  "Your request to $process activity [".$this->activity->title."] has been completed and available" ;
+            (new \App\Events\SendMessage($message));
+            $user_id = $userRepository->parseToken($this->token);
+            $user = User::find($user_id);
+            $userName = rtrim($user->first_name . ' ' . $user->last_name, ' ');
+            $user->notify(new CloneNotification($message, $process, $userName));
+        }catch(\Exception $e){
+            Log::error($e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
- Removed the CURL requests for activities cloning
- Replicate the H5P activity relational data
- Copy the content id of cloned activity to the new if exists