### PR TITLE
[CUR-635] Updated assignment links for Google classroom when publishing

### DIFF
--- a/app/Http/Controllers/Api/V1/GoogleClassroomController.php
+++ b/app/Http/Controllers/Api/V1/GoogleClassroomController.php
@@ -35,7 +35,7 @@ class GoogleClassroomController extends Controller
      * @var UserRepositoryInterface
      */
     private $userRepository;
-    
+
     /**
      * Instantiate a GoogleClassroom instance.
      *
@@ -44,7 +44,7 @@ class GoogleClassroomController extends Controller
     public function __construct(UserRepositoryInterface $userRepository)
     {
         $this->userRepository = $userRepository;
-   }
+    }
 
     /**
 	 * Get Courses
@@ -186,12 +186,12 @@ class GoogleClassroomController extends Controller
             ], 500);
         }
     }
-
+    
     /**
-	 * TurnIn a student's submission
-	 *
-	 * Identifies student's submission on a classwork assignment.
-	 * Attaches a summary page link to the assignment, and turns it in.
+     * TurnIn a student's submission
+     *
+     * Identifies student's submission on a classwork assignment.
+     * Attaches a summary page link to the assignment, and turns it in.
      * 
      * @urlParam classwork required The Id of a classwork. Example: 9
      * @bodyParam access_token string required The stringified of the GAPI access token JSON object
@@ -217,7 +217,7 @@ class GoogleClassroomController extends Controller
      * @param GcClasswork $classwork
      * @param GCTurnInRequest $turnInRequest
      * @return Response
-	 */
+     */
     public function turnIn(GcClasswork $classwork, GCTurnInRequest $turnInRequest)
     {
         $data = $turnInRequest->validated();

--- a/app/Http/Requests/V1/GCTurnInRequest.php
+++ b/app/Http/Requests/V1/GCTurnInRequest.php
@@ -25,8 +25,7 @@ class GCTurnInRequest extends FormRequest
     {
         return [
             'access_token' => 'required',
-            'course_id' => 'required|integer',
-            'activity_id' => 'required|integer'
+            'course_id' => 'required|integer'
         ];
     }
 }

--- a/app/Http/Requests/V1/GCTurnInRequest.php
+++ b/app/Http/Requests/V1/GCTurnInRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GCTurnInRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'access_token' => 'required',
+            'course_id' => 'required|integer',
+            'activity_id' => 'required|integer'
+        ];
+    }
+}

--- a/app/Models/GcClasswork.php
+++ b/app/Models/GcClasswork.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GcClasswork extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'classwork_id',
+        'path',
+        'course_id'
+    ];
+}

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -28,6 +28,8 @@ use App\Repositories\UserLogin\UserLoginRepository;
 use App\Repositories\UserLogin\UserLoginRepositoryInterface;
 use App\Repositories\OrganizationType\OrganizationTypeRepository;
 use App\Repositories\OrganizationType\OrganizationTypeRepositoryInterface;
+use App\Repositories\GcClasswork\GcClassworkRepository;
+use App\Repositories\GcClasswork\GcClassworkRepositoryInterface;
 use Illuminate\Support\ServiceProvider;
 
 class RepositoryServiceProvider extends ServiceProvider
@@ -52,6 +54,7 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->app->bind(MetricsRepositoryInterface::class, MetricsRepository::class);
         $this->app->bind(UserLoginRepositoryInterface::class, UserLoginRepository::class);
         $this->app->bind(OrganizationTypeRepositoryInterface::class, OrganizationTypeRepository::class);
+        $this->app->bind(GcClassworkRepositoryInterface::class, GcClassworkRepository::class);
     }
 
     /**

--- a/app/Repositories/GcClasswork/GcClassworkRepository.php
+++ b/app/Repositories/GcClasswork/GcClassworkRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repositories\GcClasswork;
+
+use App\Models\GcClasswork;
+use App\Repositories\BaseRepository;
+use App\Repositories\GcClasswork\GcClassworkRepositoryInterface;
+use Illuminate\Support\Collection;
+
+class GcClassworkRepository extends BaseRepository implements GcClassworkRepositoryInterface
+{
+    /**
+     * GcClassworkRepository constructor.
+     *
+     * @param GcClasswork $model
+     */
+    public function __construct(GcClasswork $model)
+    {
+        parent::__construct($model);
+    }
+}

--- a/app/Repositories/GcClasswork/GcClassworkRepositoryInterface.php
+++ b/app/Repositories/GcClasswork/GcClassworkRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Repositories\GcClasswork;
+
+use App\Models\GcClasswork;
+use App\Repositories\EloquentRepositoryInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+interface GcClassworkRepositoryInterface extends EloquentRepositoryInterface
+{
+
+}

--- a/app/Services/GoogleClassroom.php
+++ b/app/Services/GoogleClassroom.php
@@ -159,6 +159,7 @@ class GoogleClassroom implements GoogleClassroomInterface
                 'url' => $data['activity_link']
             ]
         ]);
+        $courseWork->setMaxpoints(100);
         $courseWork->setState(self::COURSEWORK_STATE_PUBLISHED);
 
         return $this->service->courses_courseWork->create($data['course_id'], $courseWork);
@@ -282,12 +283,16 @@ class GoogleClassroom implements GoogleClassroomInterface
                 $activity->shared = true;
                 $activity->save();
 
+                // Make an assignment URL with context of
+                // classroom id, user id (teacher), and the h5p activity id
+                $userId = auth()->user()->id;
+                $activityLink = '/gclass/launch/' . $userId . '/' . $course->id . '/' . $activity->id;
                 $courseWorkData = [
                     'course_id' => $course->id,
                     'topic_id' => $topic->topicId,
                     'activity_id' => $activity->id,
                     'activity_title' => $activity->title,
-                    'activity_link' => $frontURL . '/activity/' . $activity->id . '/shared'
+                    'activity_link' => $frontURL . $activityLink
                 ];
                 $courseWork = $this->createCourseWork($courseWorkData);
 

--- a/app/Services/GoogleClassroom.php
+++ b/app/Services/GoogleClassroom.php
@@ -67,7 +67,9 @@ class GoogleClassroom implements GoogleClassroomInterface
                 'or you may need to revoke the permission for this app. ');
                 // @TODO - this flow doesn't actually kick in.
                 // Request authorization from the user.
-                /*$authUrl = $client->createAuthUrl();
+                // The flow below maybe implemented later on.
+
+                /* $authUrl = $client->createAuthUrl();
                 // header("Location: $authUrl");
                 // printf("Open the following link in your browser:\n%s\n", $authUrl);
                 // print 'Enter verification code: ';
@@ -80,7 +82,7 @@ class GoogleClassroom implements GoogleClassroomInterface
                 // Check to see if there was an error.
                 if (array_key_exists('error', $accessToken)) {
                     throw new GeneralException(join(', ', $accessToken));
-                }*/
+                } */
             }
             // // Save the token to a file.
             // if (!file_exists(dirname($tokenPath))) {
@@ -244,6 +246,7 @@ class GoogleClassroom implements GoogleClassroomInterface
      * @param Project $project
      * @param int|null $courseId The id of the course
      * @return array
+     * @throws GeneralException
      */
     public function createProjectAsCourse(Project $project, $courseId = null)
     {
@@ -369,21 +372,39 @@ class GoogleClassroom implements GoogleClassroomInterface
         return $this->service->courses_students->get($courseId, "me");
     }
 
+    /**
+     * Get first student's submission for a classwork in a course.
+     *
+     * @param int $courseId
+     * @param string $classworkId
+     * @param mixed $userId
+     * @return string
+     */
     public function getFirstStudentSubmission($courseId, $classworkId, $userId = "me")
     {
         $studentSubmissions = $this->service->courses_courseWork_studentSubmissions;
-
         // Submissions associated with this courseWork for this student
         $retval = $studentSubmissions->listCoursesCourseWorkStudentSubmissions(
-            $courseId, $classworkId, array('userId' => $userId));
+            $courseId,
+            $classworkId,
+            array('userId' => $userId)
+        );
         // Grab the first submission
         $submissions = $retval->studentSubmissions;
         $first = $submissions[0];
-        //dd($submissions);
-        //var_dump($first);
+        
         return $first->id;
     }
 
+    /**
+     * Adds/modifies submission with an attachment
+     *
+     * @param int $courseId The course id
+     * @param string $classworkId The classwork id
+     * @param string $id The submission id
+     * @param string $attachmentLink The URL for attachment
+     * @return string
+     */
     public function modifySubmissionAttachment($courseId, $courseWorkId, $id, $attachmentLink)
     {
         $studentSubmissions = $this->service->courses_courseWork_studentSubmissions;
@@ -398,6 +419,14 @@ class GoogleClassroom implements GoogleClassroomInterface
         return $studentSubmissions->modifyAttachments($courseId, $courseWorkId, $id, $requestBody);
     }
 
+    /**
+     * TurnIn an assignment
+     *
+     * @param int $courseId The course id
+     * @param string $classworkId The classwork id
+     * @param string $id The submission id
+     * @return \Google_Service_Classroom_ClassroomEmpty
+     */
     public function turnIn($courseId, $courseWorkId, $id)
     {
         $studentSubmissions = $this->service->courses_courseWork_studentSubmissions;

--- a/app/Services/GoogleClassroomInterface.php
+++ b/app/Services/GoogleClassroomInterface.php
@@ -108,4 +108,43 @@ interface GoogleClassroomInterface {
      */
     public function getOrCreateTopic($data);
 
+    /**
+     * Check if student is enrolled in a class
+     *
+     * @param int $courseId
+     * @return \Google_Service_Classroom_Student
+     */
+    public function getEnrolledStudent($courseId);
+
+    /**
+     * Get first student's submission for a classwork in a course.
+     *
+     * @param int $courseId
+     * @param string $classworkId
+     * @param mixed $userId
+     * @return string
+     */
+    public function getFirstStudentSubmission($courseId, $classworkId, $userId = "me");
+
+    /**
+     * Adds/modifies submission with an attachment
+     *
+     * @param int $courseId The course id
+     * @param string $classworkId The classwork id
+     * @param string $id The submission id
+     * @param string $attachmentLink The URL for attachment
+     * @return string
+     */
+    public function modifySubmissionAttachment($courseId, $courseWorkId, $id, $attachmentLink);
+    
+    /**
+     * TurnIn an assignment
+     *
+     * @param int $courseId The course id
+     * @param string $classworkId The classwork id
+     * @param string $id The submission id
+     * @return \Google_Service_Classroom_ClassroomEmpty
+     */
+    public function turnIn($courseId, $courseWorkId, $id);
+
 }

--- a/app/Services/GoogleClassroomInterface.php
+++ b/app/Services/GoogleClassroomInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace App\Services;
+use App\Repositories\GcClasswork\GcClassworkRepositoryInterface;
 
 /**
  * Interface for Google Classroom service
@@ -41,6 +42,15 @@ interface GoogleClassroomInterface {
      * @return \Google_Client
      */
     public function getClient();
+
+    /**
+     * Set GcClasswork repository object
+     * 
+     * @param GcClassworkRepositoryInterface $gcClassworkRepository
+     *
+     * @return void
+     */
+    public function setGcClassworkObject(GcClassworkRepositoryInterface $gcClassworkRepository);
 
     /**
      * Get Google Classroom courses

--- a/database/migrations/2020_10_27_070822_create_gc_classworks_table.php
+++ b/database/migrations/2020_10_27_070822_create_gc_classworks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateGcClassworksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('gc_classworks', function (Blueprint $table) {
+            $table->id();
+            $table->text('classwork_id');
+            $table->string('path');
+            $table->text('course_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('gc_classworks');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,6 +144,10 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
     Route::get('playlists/{playlist}/lti', 'PlaylistController@loadLti');
     // xAPI Statments
     Route::post('xapi/statements', 'XapiController@saveStatement');
+    // Google Classroom Student workflow
+    Route::group(['prefix' => 'google-classroom'], function () {
+        Route::post('turnin/{classwork}', 'GoogleClassroomController@turnIn');
+    });
 
     Route::get('error', 'ErrorController@show')->name('api/error');
 


### PR DESCRIPTION
The following is included in the work:
CUR-635 - updated assignment urls, appended them with classwork id.
CUR-652 - saving classwork ids in database is done.
CUR-639 - Turn In an assignment functionality added.

Has a migration:
php artisan migrate --path=/database/migrations/2020_10_27_070822_create_gc_classworks_table.php
