### PR TITLE
[CUR-764] - Added error handling for when the 'name' property is unavailable in XAPI statements

### DIFF
--- a/app/Http/Controllers/Api/V1/CurrikiGo/OutcomeController.php
+++ b/app/Http/Controllers/Api/V1/CurrikiGo/OutcomeController.php
@@ -56,6 +56,7 @@ class OutcomeController extends Controller
                     $answers = $service->getLatestAnsweredStatementsWithResults($data);
                     $answeredIds = [];
                     if ($answers) {
+                        $answeredIds = array_keys($answers);
                         foreach ($answers as $record) {
                             $summary = $service->getStatementSummary($record);
                             $response[] = new StudentResultResource($summary);
@@ -65,9 +66,11 @@ class OutcomeController extends Controller
                     // Find any skipped interactions as well
                     $skipped = $service->getSkippedStatements($data);
                     if ($skipped) {
-                        foreach ($skipped as $record) {
-                            $summary = $service->getStatementSummary($record);
-                            $response[] = new StudentResultResource($summary);
+                        foreach ($skipped as $key => $record) {
+                            if (!in_array($key, $answeredIds)) {
+                                $summary = $service->getStatementSummary($record);
+                                $response[] = new StudentResultResource($summary);
+                            }
                         }
                     }
 

--- a/app/Services/LearnerRecordStoreService.php
+++ b/app/Services/LearnerRecordStoreService.php
@@ -275,8 +275,14 @@ class LearnerRecordStoreService implements LearnerRecordStoreServiceInterface
     {
         $summary = [];
         $target = $statement->getTarget();
-        $nameOfActivity = $target->getDefinition()->getName()->getNegotiatedLanguageString();
-        
+        $nameOfActivity = 'Unknown Quiz set';
+        $definition = $target->getDefinition();
+        // In some cases, we do not have a 'name' property for the object.
+        // So, we've added an additional check here.
+        // @todo - the LRS statements generated need to have this property
+        if (!$definition->getName()->isEmpty()) {
+            $nameOfActivity = $definition->getName()->getNegotiatedLanguageString();
+        }
         $result = $statement->getResult();
         $summary['name'] = $nameOfActivity;
         $summary['score'] = [


### PR DESCRIPTION
Also, we're now showing skipped statements for the quizzes for which we didn't find any answered statements.