### PR TITLE
Enable Questionnaire for H5P Editor

### DIFF
--- a/config/laravel-h5p.php
+++ b/config/laravel-h5p.php
@@ -42,4 +42,5 @@ return [
 	'h5p_hub_is_enabled' => FALSE,
 	'h5p_version' => '1.8.2',
 	'h5p_preview_flag' => 8,
+	'h5p_enable_lrs_content_types' => TRUE,
 ];


### PR DESCRIPTION
Enable Questionnaire for H5P Editor. 
Some libraries rely on an LRS to work and must be enabled.