### PR TITLE
[CUR-906] - Get the attempt IRI from the first index rather than the last

### DIFF
--- a/app/Http/Controllers/Api/V1/CurrikiGo/OutcomeController.php
+++ b/app/Http/Controllers/Api/V1/CurrikiGo/OutcomeController.php
@@ -48,7 +48,8 @@ class OutcomeController extends Controller
                     $contextActivities = $statement->getContext()->getContextActivities();
                     $other = $contextActivities->getOther();
                     if (!empty($other)) {
-                        $attemptIRI = end($other)->getId();
+                        // Get the attempt IRI, which is the first index of the array.
+                        $attemptIRI = current($other)->getId();
                     }
                 }
                 if (!empty($attemptIRI)) {


### PR DESCRIPTION
The 'other' context property of the XAPI statements has been reordered, and updated, so have updated our logic accordingly.