### PR TITLE
Deployment from staging to production.

### DIFF
--- a/H5P/laravel-h5p/src/LaravelH5p/Helpers/H5pHelper.php
+++ b/H5P/laravel-h5p/src/LaravelH5p/Helpers/H5pHelper.php
@@ -229,4 +229,33 @@ class H5pHelper
         $editor->processParameters($content['id'], $content['library'], $params->params, $oldLibrary, $oldParams);
         return $content['id'];
     }
+
+    public static function rearrangeContentParams(&$content, $library)
+    {
+        if ($content['libraryName'] === $library && $library === 'H5P.InteractiveBook') {
+            $params = json_decode($content['params']);
+            // get chapters with updated params
+            $chaptersRearranged = array_filter($params->chapters, function($item) { return property_exists($item, 'chapter'); });
+            if (empty($chaptersRearranged)) {
+                $chaptersRearranged = array_map(function($chapter) { 
+                    return (object) array('chapter' => $chapter, "lockPage" => false); 
+                }, $params->chapters);
+                $params->chapters = $chaptersRearranged;
+                $content['params'] = json_encode($params);
+            }
+            
+            $filtered = json_decode($content['filtered']);
+            if ($filtered) {
+                // get chapters with updated filtered
+                $chaptersRearrangedF = array_filter($filtered->chapters, function($item) { return property_exists($item, 'chapter'); });
+                if (empty($chaptersRearrangedF)) {
+                    $chaptersRearrangedF = array_map(function($chapter) { 
+                        return (object) array('chapter' => $chapter, "lockPage" => false); 
+                    }, $filtered->chapters);
+                    $filtered->chapters = $chaptersRearrangedF;
+                    $content['filtered'] = json_encode($filtered);
+                }
+            }
+        }
+    }
 }

--- a/H5P/laravel-h5p/src/LaravelH5p/LaravelH5p.php
+++ b/H5P/laravel-h5p/src/LaravelH5p/LaravelH5p.php
@@ -237,6 +237,7 @@ class LaravelH5p
                 'H5P' => trans('laravel-h5p.h5p'),
             ),
             'hubIsEnabled' => config('laravel-h5p.h5p_hub_is_enabled'),
+            'reportingIsEnabled' => config('laravel-h5p.h5p_enable_lrs_content_types'),
         );
 
         if (Auth::check()) {

--- a/H5P/laravel-h5p/src/LaravelH5p/Repositories/LaravelH5pRepository.php
+++ b/H5P/laravel-h5p/src/LaravelH5p/Repositories/LaravelH5pRepository.php
@@ -744,6 +744,7 @@ class LaravelH5pRepository implements H5PFrameworkInterface
             }
         }
 
+        H5pHelper::rearrangeContentParams($content, 'H5P.InteractiveBook');
         return $content;
     }
 

--- a/app/CurrikiGo/LRS/InteractionFactory.php
+++ b/app/CurrikiGo/LRS/InteractionFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\CurrikiGo\LRS;
+
+use \TinCan\Statement;
+use App\CurrikiGo\LRS\Interactions\ChoiceSummary;
+use App\CurrikiGo\LRS\Interactions\FillInSummary;
+
+/**
+ * Factory Class for Interactions
+ */
+class InteractionFactory
+{
+    
+    /**
+     * Initialize and return an interaction object.
+     *
+     * @param Statement $statement
+     * @return InteractionSummary|null
+     */
+    public function initInteraction(Statement $statement)
+    {
+        $target = $statement->getTarget();
+        $definition = $target->getDefinition();
+        $interactionType = $definition->getInteractionType();
+        switch ($interactionType) {
+            case 'choice':
+                return new ChoiceSummary($statement);
+            case 'fill-in':
+                return new FillInSummary($statement);
+            default:
+                return null;
+        }
+    }
+}

--- a/app/CurrikiGo/LRS/InteractionSummary.php
+++ b/app/CurrikiGo/LRS/InteractionSummary.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\CurrikiGo\LRS;
+
+/**
+ * Abstract class for Interaction Summary
+ */
+abstract class InteractionSummary
+{
+    
+    /**
+     * An XAPI statement
+     * 
+     * @var \Statement
+     */
+    protected $statement;
+
+    /**
+     * Get Statement
+     *
+     * @return \Statement
+     */
+    public function getStatement()
+    {
+        return $this->statement;
+    }
+
+    /**
+     * Get Target Object
+     *
+     * @return \Activity
+     */
+    public function getTarget()
+    {
+        return $this->statement->getTarget();
+    }
+
+    /**
+     * Get the Object Definition
+     *
+     * @return \ActivityDefinition
+     */
+    public function getDefinition()
+    {
+        $target = $this->getTarget();
+        return $target->getDefinition();
+    }
+
+    /**
+     * Get Name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        $definition = $this->getDefinition();
+        $nameOfActivity = '';
+        if (!$definition->getName()->isEmpty()) {
+            $nameOfActivity = $definition->getName()->getNegotiatedLanguageString();
+        }
+        return $nameOfActivity;
+    }
+
+    /**
+     * Get Description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        $definition = $this->getDefinition();
+        $description = '';
+        if (!$definition->getDescription()->isEmpty()) {
+            $description = $definition->getDescription()->getNegotiatedLanguageString();
+        }
+        return $description;
+    }
+
+    /**
+     * Get the interaction type
+     *
+     * @return string
+     */
+    public function getInteractionType()
+    {
+        $definition = $this->getDefinition();
+        return $definition->getInteractionType();
+    }
+
+    /**
+     * Get the correct response pattern.
+     *
+     * @return string
+     */
+    public function getCorrectResponsesPattern()
+    {
+        $definition = $this->getDefinition();
+        return $definition->getCorrectResponsesPattern();
+    }
+
+    /**
+     * Get statement result
+     *
+     * @return \Result
+     */
+    public function getResult()
+    {
+        return $this->statement->getResult();
+    }
+
+    /**
+     * Whether an interaction is scorable or not.
+     *
+     * @return bool
+     */
+    public function isScorable()
+    {
+        return (!empty($this->getCorrectResponsesPattern()) ? true : false);
+    }
+
+    /**
+     * Get the statement verb
+     *
+     * @return string
+     */
+    public function getVerb()
+    {
+        return $this->getStatement()->getVerb()->getDisplay()->getNegotiatedLanguageString();
+    }
+
+    /**
+     * Get statement response
+     *
+     * @return mixed
+     */
+    public function getRawResponse()
+    {
+        return $this->getResult()->getResponse();
+    }
+
+    /**
+     * Abstract method for the interaction summary.
+     * Will be implemented by sub-classes
+     */
+    abstract public function summary();
+    
+}

--- a/app/CurrikiGo/LRS/Interactions/ChoiceSummary.php
+++ b/app/CurrikiGo/LRS/Interactions/ChoiceSummary.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\CurrikiGo\LRS\Interactions;
+
+use App\CurrikiGo\LRS\InteractionSummaryInterface;
+use App\CurrikiGo\LRS\InteractionSummary;
+use \TinCan\Statement;
+
+/**
+ * Choice Interaction summary class
+ */
+class ChoiceSummary extends InteractionSummary
+{
+    /**
+     * Initialize
+     *
+     * @param Statement $statement
+     */
+    public function __construct(Statement $statement)
+    {
+        $this->statement = $statement;
+    }
+
+    /**
+     * Interaction summary
+     *
+     * @return array
+     */
+    public function summary()
+    {
+        $definition = $this->getDefinition();
+        // $summary['correct-pattern'] = $this->getCorrectResponsesPattern();
+        $summary['interaction'] = $this->getInteractionType();
+        $result = $this->getResult();
+        $summary['name'] = $this->getName();
+        $summary['description'] = $this->getDescription();
+        $summary['scorable'] = $this->isScorable();
+        if ($result) {
+            $summary['choices'] = $this->getChoicesListArray();
+            $summary['response'] = $this->getDescriptiveResponses();
+            $summary['raw-response'] = $this->getRawResponse();
+            // Get Interaction type
+        }
+        // Get Verb
+        $summary['verb'] = $this->getVerb();
+        return $summary;
+    }
+
+    /**
+     * Get student response array
+     *
+     * @return array
+     */
+    public function getResponses()
+    {
+        return explode('[,]', $this->getResult()->getResponse());
+    }
+
+    /**
+     * Get descriptive student responses
+     *
+     * @return array
+     */
+    public function getDescriptiveResponses()
+    {
+        // student responses.
+        $responses = $this->getResponses();
+        $choices = $this->getChoicesListArray();
+        $answers = [];
+        foreach ($responses as $value) {
+            $answers[] = $choices[$value];
+        }
+        return $answers;
+    }
+
+    /**
+     * Get quiz choices array
+     *
+     * @return array
+     */
+    public function getChoicesListArray()
+    {
+        return $this->prepareChoiceList($this->getRawChoices());
+    }
+
+    /**
+     * Get raw quiz choices
+     *
+     * @return array
+     */
+    private function getRawChoices()
+    {
+        $definition = $this->getDefinition();
+        return $definition->getChoices();
+    }
+    
+    /**
+     * Prepare choice list in an array.
+     * 
+     * @param array $list
+     * @param string $languageKey Defaults to en-US
+     * @return array
+     */
+    private function prepareChoiceList($list, $languageKey = 'en-US')
+    {
+        if (!is_array($list)) {
+            return $list;
+        }
+        $return = [];
+        foreach ($list as $values) {
+            $return[$values['id']] = $values['description'][$languageKey];
+        }
+        return $return;
+    }
+}

--- a/app/CurrikiGo/LRS/Interactions/FillInSummary.php
+++ b/app/CurrikiGo/LRS/Interactions/FillInSummary.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\CurrikiGo\LRS\Interactions;
+
+use App\CurrikiGo\LRS\InteractionSummaryInterface;
+use App\CurrikiGo\LRS\InteractionSummary;
+use \TinCan\Statement;
+
+/**
+ * Fill-in Interaction summary class
+ */
+class FillInSummary extends InteractionSummary// implements InteractionSummaryInterface
+{
+
+    /**
+     * Initialize
+     *
+     * @param Statement $statement
+     */
+    public function __construct(Statement $statement)
+    {
+        $this->statement = $statement;
+    }
+
+    /**
+     * Interaction summary
+     *
+     * @return array
+     */
+    public function summary()
+    {
+        $definition = $this->getDefinition();
+        // $summary['correct-pattern'] = $this->getCorrectResponsesPattern();
+        $summary['interaction'] = $this->getInteractionType();
+        $result = $this->getResult();
+        $summary['name'] = $this->getName();
+        $summary['description'] = $this->getDescription();
+        $summary['scorable'] = $this->isScorable();
+        if ($result) {
+            $summary['response'] = $this->getFormattedResponse();
+            $summary['raw-response'] = $this->getRawResponse();
+        }
+        // Get Verb
+        $summary['verb'] = $this->getVerb();
+        return $summary;
+    }
+
+    /**
+     * Get formatted response
+     *
+     * @return string
+     */
+    public function getFormattedResponse()
+    {
+        // student responses.
+        $response = $this->getRawResponse();
+        return $response;
+    }
+}

--- a/app/Http/Controllers/Api/V1/CurrikiGo/LmsController.php
+++ b/app/Http/Controllers/Api/V1/CurrikiGo/LmsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\V1\CurrikiGo;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\ProjectPublicResource;
 use App\Repositories\CurrikiGo\LmsSetting\LmsSettingRepositoryInterface;
+use App\Repositories\Activity\ActivityRepositoryInterface;
 use App\Repositories\Project\ProjectRepositoryInterface;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -19,16 +20,20 @@ class LmsController extends Controller
 {
     private $lmsSettingRepository;
     private $projectRepository;
+    private $activityRepository;
 
     /**
      * LmsController constructor.
      *
      * @param $lmsSettingRepository LmsSettingRepositoryInterface
+     * @param $projectRepository ProjectRepositoryInterface
+     * @param $activityRepository ActivityRepositoryInterface
      */
-    public function __construct(LmsSettingRepositoryInterface $lmsSettingRepository, ProjectRepositoryInterface $projectRepository)
+    public function __construct(LmsSettingRepositoryInterface $lmsSettingRepository, ProjectRepositoryInterface $projectRepository, ActivityRepositoryInterface $activityRepository)
     {
         $this->lmsSettingRepository = $lmsSettingRepository;
         $this->projectRepository = $projectRepository;
+        $this->activityRepository = $activityRepository;
     }
 
     /**
@@ -64,6 +69,26 @@ class LmsController extends Controller
 
         return response([
             'projects' => ProjectPublicResource::collection($projects),
+        ], 200);
+    }
+
+    public function activities(Request $request)
+    {
+        $request->validate([
+            'query' => 'string|max:255',
+            'from' => 'integer',
+            'subject' => 'string|max:255',
+            'level' => 'string|max:255',
+            'start' => 'string|max:255',
+            'end' => 'string|max:255',
+            'author' => 'string|max:255',
+            'private' => 'integer',
+            'userEmail' => 'string|required|max:255',
+            'ltiClientId' => 'integer|required',
+        ]);
+
+        return response([
+            'activities' => $this->activityRepository->ltiSearchForm($request),
         ], 200);
     }
 }

--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -195,12 +195,18 @@ class PlaylistController extends Controller
      * @param Playlist $playlist
      * @return Response
      */
-    // TODO: need to update
     public function loadLti(Playlist $playlist)
     {
+        $availablePlaylist = $this->playlistRepository->getPlaylistWithProject($playlist);
+        if ($availablePlaylist) {
+            return response([
+                'playlist' => new PlaylistResource($availablePlaylist),
+            ], 200);
+        }
+
         return response([
-            'playlist' => new PlaylistResource($this->playlistRepository->getPlaylistWithProject($playlist)),
-        ], 200);
+            'message' => 'Playlist is not available.',
+        ], 404);
     }
 
     /**

--- a/app/Http/Requests/V1/SearchRequest.php
+++ b/app/Http/Requests/V1/SearchRequest.php
@@ -28,7 +28,7 @@ class SearchRequest extends FormRequest
             'negativeQuery' => 'string|max:255',
             'indexing' => 'array|in:null,1,2,3',
             'startDate' => 'date',
-            'endDate' => 'date',
+            'endDate' => 'date|after_or_equal:startDate',
             'userIds' => 'array|exists:App\User,id',
             'h5pLibraries' => 'array|exists:App\Models\ActivityItem,h5pLib',
             'subjectIds' => 'array|exists:App\Models\Activity,subject_id',

--- a/app/Http/Resources/V1/SearchResource.php
+++ b/app/Http/Resources/V1/SearchResource.php
@@ -18,12 +18,15 @@ class SearchResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'playlist_id' => $this->when(isset($this->playlist_id), $this->playlist_id),
             'thumb_url' => (isset($this->thumb_url) ? $this->thumb_url : $this->thumbUrl),
             'title' => (isset($this->title) ? $this->title : $this->name),
             'description' => $this->when(isset($this->description), $this->description),
+            'content' => $this->when(isset($this->content), $this->content),
             'favored' => $this->when(isset($this->favored), $this->favored),
             'model' => $this->modelType,
-            'user' => new UserResource($this->user)
+            'user' => new UserResource($this->user),
+            'created_at' => $this->created_at
         ];
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -159,6 +159,10 @@ class Project extends Model
      */
     public function getFavoredAttribute()
     {
-        return $this->favoredByUsers->find(auth()->user()->id) ? true : false;
+        $user = auth()->user();
+        if ($user) {
+            return $this->favoredByUsers->find(auth()->user()->id) ? true : false;
+        }
+        return false;
     }
 }

--- a/app/Repositories/Activity/ActivityRepository.php
+++ b/app/Repositories/Activity/ActivityRepository.php
@@ -2,9 +2,11 @@
 
 namespace App\Repositories\Activity;
 
+use App\User;
 use App\Models\Activity;
 use App\Models\Playlist;
 use App\Models\Project;
+use App\Models\CurrikiGo\LmsSetting;
 use App\Repositories\Activity\ActivityRepositoryInterface;
 use App\Repositories\BaseRepository;
 use App\Repositories\H5pElasticsearchField\H5pElasticsearchFieldRepositoryInterface;
@@ -353,6 +355,66 @@ class ActivityRepository extends BaseRepository implements ActivityRepositoryInt
                 }
             }
         }
+    }
+
+    /**
+     * Gets activities for LTI external tool search from CurrikiGo
+     * @param array $data
+     * @return array
+     */
+    public function ltiSearchForm($request)
+    {
+        // Fetch Elastic Search results
+        $data = [
+            'query' => $request->input('query', ''),
+            'from' => $request->input('from', 0),
+            'size' => 11,
+            'model' => 'activities',
+            'indexing' => intval($request->input('private', 0)) === 1 ? [] : [3],
+        ];
+
+        // Check LMS settings for authorization when searching private projects
+        if (empty($data['indexing'])) {
+            // There can be many LmsSettings for different users sharing the same
+            // lti_client_id. Need to find the user first
+            $user = User::where('email', $request->input('userEmail'))->first();
+            $lmsSetting = LmsSetting::where('lti_client_id', $request->input('ltiClientId'))
+                ->where('user_id', $user->id)
+                ->first();
+
+            if (empty($user) || empty($lmsSetting)) {
+                return [];
+            } else {
+                $data['userIds'] = [$lmsSetting->user_id];
+            }
+        }
+
+        // If a an author is provided, limit to projects from that user only
+        if ($request->has('author') && $request->input('private', 0) !== '1') {
+            $authors = User::where('email', 'like', '%' . $request->input('author') . '%')
+                ->orWhere('name', 'like', '%' . $request->input('author') . '%')
+                ->orWhere('first_name', 'like', '%' . $request->input('author') . '%')
+                ->orWhere('last_name', 'like', '%' . $request->input('author') . '%')
+                ->pluck('id');
+
+            if ($authors->isEmpty()) {
+                return [];
+            }
+            $data['userIds'] = $authors->toArray();
+        }
+
+        $data['subjectIds'] = $request->has('subject') ? [$request->input('subject')] : [];
+        $data['educationLevelIds'] = $request->has('level') ? [$request->input('level')] : [];
+
+        if ($request->has('start')) {
+            $data['startDate'] = $request->input('start', '');
+        }
+
+        if ($request->has('end')) {
+            $data['endDate'] = $request->input('end', '');
+        }
+
+        return $this->advanceSearchForm($data);
     }
 
     /**

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -171,11 +171,12 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
      */
     public function getPlaylistWithProject(Playlist $playlist)
     {
-        return $this->model->where('id', $playlist->id)
+        return $this->model::whereHas('project')
+            ->where('id', $playlist->id)
             ->with('project')
             ->first();
     }
-    
+
     /**
      * To Populate missing order number, One time script
      */

--- a/app/Services/LearnerRecordStoreConstantsInterface.php
+++ b/app/Services/LearnerRecordStoreConstantsInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+/**
+ * Interface for Learner Record Store constants
+ */
+interface LearnerRecordStoreConstantsInterface
+{
+    /**
+     * Ending-point extension IRI
+     * 
+     * @var string
+     */
+    const EXTENSION_ENDING_POINT_IRI = 'http://id.tincanapi.com/extension/ending-point';
+
+    /**
+     * H5P xAPI subContent ID 
+     * 
+     * @var string
+     */
+    const EXTENSION_H5P_SUBCONTENT_ID = 'http://h5p.org/x-api/h5p-subContentId';
+    
+    /**
+     * Answered verb id for XAPI statements
+     * 
+     * @var string
+     */
+    const ANSWERED_VERB_ID = 'http://adlnet.gov/expapi/verbs/answered';
+
+    /**
+     * Completed verb id for XAPI statements
+     * 
+     * @var string
+     */
+    const COMPLETED_VERB_ID = 'http://adlnet.gov/expapi/verbs/completed';
+
+    /**
+     * Skipped verb id for XAPI statements
+     * 
+     * @var string
+     */
+    const SKIPPED_VERB_ID = 'http://id.tincanapi.com/verb/skipped';
+
+    /**
+     * Attempted verb id for XAPI statements
+     * 
+     * @var string
+     */
+    const ATTEMPTED_VERB_ID = 'http://adlnet.gov/expapi/verbs/attempted';
+
+    /**
+     * Interacted verb id for XAPI statements
+     * 
+     * @var string
+     */
+    const INTERACTED_VERB_ID = 'http://adlnet.gov/expapi/verbs/interacted';
+}

--- a/app/Services/LearnerRecordStoreService.php
+++ b/app/Services/LearnerRecordStoreService.php
@@ -12,6 +12,7 @@ use \TinCan\Verb;
 use \TinCan\Activity;
 use \TinCan\Extensions;
 use \TinCan\LRSResponse;
+use App\CurrikiGo\LRS\InteractionFactory;
 
 /**
  * Learner Record Store Service class
@@ -219,12 +220,17 @@ class LearnerRecordStoreService implements LearnerRecordStoreServiceInterface
                 $contextActivities = $statement->getContext()->getContextActivities();
                 $category = $contextActivities->getCategory();
                 if (!empty($category) && !empty($result)) {
-                    // Get activity subID for this statement.
                     // Each quiz within the activity is identified by a unique GUID.
                     // We only need to take the most recent submission on an activity into account.
                     // We've sorted statements in descending order, so the first entry for a subId is the latest
+                    // We also need to exclude 'answered' statements for the aggregate types
+                    // Rule for that is, if we're able to find more than 1 answered statements for the object id, for the same attempt
+                    // then it's an aggregate.
+                    $objectId = $statement->getTarget()->getId();
+                    $isAggregateH5P = $this->isAggregateH5P($data, $objectId); 
+                    // Get activity subID for this statement.
                     $h5pSubContentId = $this->getH5PSubContenIdFromStatement($statement);
-                    if (!array_key_exists($h5pSubContentId, $filtered)) {
+                    if (!array_key_exists($h5pSubContentId, $filtered) && !$isAggregateH5P) {
                         $filtered[$h5pSubContentId] = $statement;
                     }
                 }
@@ -266,6 +272,119 @@ class LearnerRecordStoreService implements LearnerRecordStoreServiceInterface
     }
 
     /**
+     * Get the 'attempted' statements from LRS based on filters
+     * 
+     * @param array $data An array of filters.
+     * @throws GeneralException
+     * @return array
+     */
+    public function getAttemptedStatements(array $data)
+    {
+        $attempted = $this->getStatementsByVerb('attempted', $data);
+        $filtered = [];
+        if ($attempted) {
+            // iterate and find the statements that have results.
+            foreach ($attempted as $statement) {
+                // Get Parent context
+                $contextActivities = $statement->getContext()->getContextActivities();
+                $parent = $contextActivities->getParent();
+                
+                if (!empty($parent)) {
+                    $objectId = $statement->getTarget()->getId();
+                    $isAggregateH5P = $this->isAggregateH5P($data, $objectId); 
+                    // Get activity subID for this statement.
+                    $h5pSubContentId = $this->getH5PSubContenIdFromStatement($statement);
+                    if (!array_key_exists($h5pSubContentId, $filtered) && !$isAggregateH5P) {
+                        $filtered[$h5pSubContentId] = $statement;
+                    }
+                }
+            }
+        }
+        return $filtered;
+    }
+
+    /**
+     * Get the 'interacted' statements from LRS based on filters
+     * Filters the ones that have the results
+     * 
+     * @param array $data An array of filters.
+     * @throws GeneralException
+     * @return array
+     */
+    public function getInteractedResultStatements(array $data)
+    {
+        $attempted = $this->getStatementsByVerb('interacted', $data);
+        $allowedInteractions = $this->allowedInteractionsList();
+        $filtered = [];
+        if ($attempted) {
+            // iterate and find the statements that have results.
+            foreach ($attempted as $statement) {
+                $result = $statement->getResult();
+                // Get Category context
+                $contextActivities = $statement->getContext()->getContextActivities();
+                $category = $contextActivities->getCategory();
+                $categoryId = '';
+                $h5pInteraction = '';
+                if (!empty($category)) {
+                    $categoryId = end($category)->getId();
+                    $h5pInteraction = explode("/", $categoryId);
+                    $h5pInteraction = end($h5pInteraction);
+                }
+                
+                if (!empty($category) && in_array($h5pInteraction, $allowedInteractions) && !empty($result)) {
+                    $objectId = $statement->getTarget()->getId();
+                    // Get activity subID for this statement.
+                    $h5pSubContentId = $this->getH5PSubContenIdFromStatement($statement);
+                    if (!array_key_exists($h5pSubContentId, $filtered)) {
+                        $filtered[$h5pSubContentId] = $statement;
+                    }
+                }
+            }
+        }
+        return $filtered;
+    }
+
+    /**
+     * Find if the statement is for an aggregate H5P
+     * 
+     * @param array $data An array of filters.
+     * @param string $objectId An activity Object Id
+     * @throws GeneralException
+     * @return bool
+     */
+    public function isAggregateH5P(array $data, string $objectId)
+    {
+        $attemptId = $data['activity'];
+        // Get all related answered statetmentn for the object id
+        $data['activity'] = $objectId;
+        $allAnswers = $this->getAnsweredStatements($data);
+        $count = 0;
+        if ($allAnswers) {
+            // iterate and find the statements that have results & Category.
+            foreach ($allAnswers as $statement) {
+                $attemptIRI = '';
+                $result = $statement->getResult();
+                // Get Category context
+                $contextActivities = $statement->getContext()->getContextActivities();
+                $category = $contextActivities->getCategory();
+                
+                $other = $contextActivities->getOther();
+                if (!empty($other)) {
+                    $attemptIRI = end($other)->getId();
+                }
+                if ($attemptIRI === $attemptId && (!empty($category) && !empty($result))) {
+                    ++$count;
+                }
+                // If we have 2 or more records, then it's an aggregate H5P statement
+                if ($count > 1) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Get summary of an 'answered' statement
      * 
      * @param Statement $statement A TinCan API statement object.
@@ -285,11 +404,20 @@ class LearnerRecordStoreService implements LearnerRecordStoreServiceInterface
         }
         $result = $statement->getResult();
         $summary['name'] = $nameOfActivity;
-        $summary['score'] = [
-            'raw' => $result->getScore()->getRaw(),
-            'max' => $result->getScore()->getMax(),
-        ];
-        $summary['duration'] = $this->formatDuration($result->getDuration());
+        if ($result) {
+            $summary['score'] = [
+                'raw' => $result->getScore()->getRaw(),
+                'max' => $result->getScore()->getMax(),
+            ];
+            $summary['duration'] = $this->formatDuration($result->getDuration());
+        } else {
+            $summary['score'] = [
+                'raw' => 0,
+                'max' => 0
+            ];
+            $summary['duration'] = '00:00';
+        }
+        
         // Get activity duration
         $extensions = $statement->getContext()->getExtensions();
         $endingPoint = $this->getEndingPointExtension($extensions);
@@ -300,6 +428,19 @@ class LearnerRecordStoreService implements LearnerRecordStoreServiceInterface
         $summary['verb'] = $statement->getVerb()->getDisplay()->getNegotiatedLanguageString();
         
         return $summary;
+    }
+
+    /**
+     * Get summary of an 'interacted' (non-scoring) statement
+     * 
+     * @param Statement $statement A TinCan API statement object.
+     * @return array
+     */
+    public function getNonScoringStatementSummary(Statement $statement)
+    {
+        $interactionFactory = new InteractionFactory();
+        $interaction = $interactionFactory->initInteraction($statement);
+        return $interaction->summary();
     }
 
     /**
@@ -366,9 +507,25 @@ class LearnerRecordStoreService implements LearnerRecordStoreServiceInterface
         $verbsList = [
             'answered' => self::ANSWERED_VERB_ID,
             'completed' => self::COMPLETED_VERB_ID,
-            'skipped' => self::SKIPPED_VERB_ID
+            'skipped' => self::SKIPPED_VERB_ID,
+            'attempted' => self::ATTEMPTED_VERB_ID,
+            'interacted' => self::INTERACTED_VERB_ID
         ];
         return (array_key_exists($verb, $verbsList) ? $verbsList[$verb] : false);
     }
-    
+
+    /**
+     * List of allowed non-scoring interactions.
+     * 
+     * @return array
+     */
+    public function allowedInteractionsList()
+    {
+        $allowed = [
+            'H5P.SimpleMultiChoice-1.1',
+            'H5P.OpenEndedQuestion-1.0',
+        ];
+        return $allowed;
+    }
+
 }

--- a/app/Services/LearnerRecordStoreServiceInterface.php
+++ b/app/Services/LearnerRecordStoreServiceInterface.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace App\Services;
+
+use App\Services\LearnerRecordStoreConstantsInterface;
 use \TinCan\Statement;
 use \TinCan\Agent;
 use \TinCan\Verb;
@@ -10,44 +12,9 @@ use \TinCan\Extensions;
 /**
  * Interface for Learner Record Store service
  */
-interface LearnerRecordStoreServiceInterface
+interface LearnerRecordStoreServiceInterface extends LearnerRecordStoreConstantsInterface
 {
 
-    /**
-     * Ending-point extension IRI
-     * 
-     * @var string
-     */
-    const EXTENSION_ENDING_POINT_IRI = 'http://id.tincanapi.com/extension/ending-point';
-
-    /**
-     * H5P xAPI subContent ID 
-     * 
-     * @var string
-     */
-    const EXTENSION_H5P_SUBCONTENT_ID = 'http://h5p.org/x-api/h5p-subContentId';
-    
-    /**
-     * Answered verb id for XAPI statements
-     * 
-     * @var string
-     */
-    const ANSWERED_VERB_ID = 'http://adlnet.gov/expapi/verbs/answered';
-
-    /**
-     * Completed verb id for XAPI statements
-     * 
-     * @var string
-     */
-    const COMPLETED_VERB_ID = 'http://adlnet.gov/expapi/verbs/completed';
-
-    /**
-     * Skipped verb id for XAPI statements
-     * 
-     * @var string
-     */
-    const SKIPPED_VERB_ID = 'http://id.tincanapi.com/verb/skipped';
-    
     /**
      * Save Statement
      *
@@ -181,5 +148,49 @@ interface LearnerRecordStoreServiceInterface
      * @return array
      */
     public function getSkippedStatements(array $data);
+
+    /**
+     * Get the 'attempted' statements from LRS based on filters
+     * 
+     * @param array $data An array of filters.
+     * @throws GeneralException
+     * @return array
+     */
+    public function getAttemptedStatements(array $data);
+
+    /**
+     * Find if the answered statement is for an aggregate H5P
+     * 
+     * @param array $data An array of filters.
+     * @param string $objectId An activity Object Id
+     * @throws GeneralException
+     * @return bool
+     */
+    public function isAggregateH5P(array $data, string $objectId);
+
+    /**
+     * List of allowed non-scoring interactions.
+     * 
+     * @return array
+     */
+    public function allowedInteractionsList();
+
+    /**
+     * Get the 'interacted' statements from LRS based on filters
+     * Filters the ones that have the results
+     * 
+     * @param array $data An array of filters.
+     * @throws GeneralException
+     * @return array
+     */
+    public function getInteractedResultStatements(array $data);
+
+    /**
+     * Get summary of an 'interacted' (non-scoring) statement
+     * 
+     * @param Statement $statement A TinCan API statement object.
+     * @return array
+     */
+    public function getNonScoringStatementSummary(Statement $statement);
 
 }

--- a/config/laravel-h5p.php
+++ b/config/laravel-h5p.php
@@ -42,4 +42,5 @@ return [
 	'h5p_hub_is_enabled' => FALSE,
 	'h5p_version' => '1.8.2',
 	'h5p_preview_flag' => 8,
+	'h5p_enable_lrs_content_types' => TRUE,
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -158,6 +158,7 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
     Route::get('h5p/embed/{id}', 'H5pController@embed');
     // Public route used for LTI previews
     Route::post('go/lms/projects', 'CurrikiGo\LmsController@projects');
+    Route::post('go/lms/activities', 'CurrikiGo\LmsController@activities');
     // LTI Playlist
     Route::get('playlists/{playlist}/lti', 'PlaylistController@loadLti');
     // xAPI Statments

--- a/storage/responses/outcome/student-result-summary.json
+++ b/storage/responses/outcome/student-result-summary.json
@@ -8,7 +8,7 @@
             },
             "duration": "00:13",
             "ending-point": "00:02",
-            "verb": "answered",
+            "verb": "answered"
         },
         {
             "name": "Single Choice Set",
@@ -18,7 +18,7 @@
             },
             "duration": "00:32",
             "ending-point": "00:03",
-            "verb": "answered",
+            "verb": "answered"
         },
         {
             "name": "2nd Single Choice Set",
@@ -28,7 +28,7 @@
             },
             "duration": "00:18",
             "ending-point": "00:03",
-            "verb": "answered",
+            "verb": "answered"
         },
         {
             "name": "Multiple Choice",
@@ -38,7 +38,7 @@
             },
             "duration": "00:11",
             "ending-point": "00:04",
-            "verb": "answered",
+            "verb": "answered"
         },
         {
             "name": "True/False Question",
@@ -48,7 +48,7 @@
             },
             "duration": "00:15",
             "ending-point": "00:05",
-            "verb": "answered",
+            "verb": "answered"
         },
         {
             "name": "2nd True/False Question",
@@ -58,7 +58,7 @@
             },
             "duration": "00:14",
             "ending-point": "00:05",
-            "verb": "answered",
+            "verb": "answered"
         },
         {
             "name": "Summary",
@@ -68,7 +68,49 @@
             },
             "duration": "00:03",
             "ending-point": "00:06",
-            "verb": "answered",
+            "verb": "answered"
+        }
+    ],
+    "non-scoring": [
+        {
+          "correct-pattern": null,
+          "interaction": "choice",
+          "name": "",
+          "description": "Were there some dominant emotions amongst the four emotions listed in the above question? (Please select all that apply)",
+          "scorable": false,
+          "choices": [
+            "Introspective",
+            "Encouraged",
+            "Joyful",
+            "Secure",
+            "No dominant components. I felt a combination of these emotions"
+          ],
+          "response": [
+            "Introspective",
+            "Encouraged",
+            "Secure"
+          ],
+          "raw-response": "0[,]1[,]3",
+          "verb": "interacted"
+        },
+        {
+          "correct-pattern": null,
+          "interaction": "choice",
+          "name": "",
+          "description": "How introspective \u2013 encouraged \u2013 joyful - secure were you while completing the task? (Consider your overall response as a combination of these emotions)\u00a0*",
+          "scorable": false,
+          "choices": [
+            "Very highly",
+            "Highly",
+            "Moderately",
+            "A little",
+            "Not at all"
+          ],
+          "response": [
+            "Highly"
+          ],
+          "raw-response": "1",
+          "verb": "interacted"
         }
     ]
 }

--- a/storage/responses/search/advance.json
+++ b/storage/responses/search/advance.json
@@ -5,14 +5,16 @@
             "thumb_url": "/storage/uploads/5f1083871600f.png",
             "title": "",
             "model": "Activity",
-            "user": null
+            "user": null,
+            "created_at": "2020-07-29T20:51:30.000000Z"
         },
         {
             "id": 999,
             "thumb_url": "/storage/uploads/5ef42a8dc4386.png",
             "title": "About The National Parks",
             "model": "Playlist",
-            "user": null
+            "user": null,
+            "created_at": "2020-07-29T20:51:30.000000Z"
         },
         {
             "id": 999,
@@ -21,7 +23,8 @@
             "description": "Algebra 1 ACPS Curriki Resources",
             "favored": false,
             "model": "Project",
-            "user": null
+            "user": null,
+            "created_at": "2020-07-29T20:51:30.000000Z"
         }
     ],
     "meta": {

--- a/storage/responses/search/dashboard.json
+++ b/storage/responses/search/dashboard.json
@@ -5,14 +5,16 @@
             "thumb_url": null,
             "title": "",
             "model": "Activity",
-            "user": null
+            "user": null,
+            "created_at": "2020-07-29T20:51:30.000000Z"
         },
         {
             "id": 9,
             "thumb_url": "/storage/uploads/i6kOcAFcvBGd3yabpnbUKaqUARdUQsJ8LJLzzDUW.png",
             "title": "Chapter 2: What is money?",
             "model": "Playlist",
-            "user": null
+            "user": null,
+            "created_at": "2020-07-29T20:51:30.000000Z"
         },
         {
             "id": 9,
@@ -21,7 +23,8 @@
             "description": "You have important decisions to make about your educations and career – wouldn’t it be nice if you could better understand the forces of globalization and automation first? What information do you need to gauge salary prospects, the risk of automation, and foreign competition as you compare your options?",
             "favored": false,
             "model": "Project",
-            "user": null
+            "user": null,
+            "created_at": "2020-07-29T20:51:30.000000Z"
         }
     ],
     "meta": {


### PR DESCRIPTION
* [CUR-814] Canvas deeplinking integration (#214)

* canvas deeplinking integration updated

* CUR-788 - Fixed summary page for interacted/attempted quizzes. (#215)

* Fix issue with share playlist (#218)

* Added checks on to date to be same or after the from date. (#219)

Added the date in search response.

* enable Questionnaire for H5P Editor (#220)

Approved on Waqar's request.

* CUR-870 - Removed aggregate line-items from the summary page for complex activities. (#221)

* [CUR-814] LTI search changes (#223)

Implemented changes to LTI search

* [CUR-898] Adding student responses for non-scoring activities on the summary page. (#225)

* CUR-898 - Adding student responses for non-scoring interactions on the summary page.

* CUR-898 - Updating doc blocks.

* CUR-898 - Minor code fixes.

* Updated LTI tool private search endpoint to use the LMS user's email as a filtering parameter instead of just ltiClientId (#227)

* CUR-906 - Get the attempt IRI from the first index rather than last now in the 'other' context property of the XAPI statements. (#228)

* Pagination fix (#230)

* IB content backward compatibility for sequential logic (#229)

* IB content backward compatibility for sequential logic

* h5p enabled reporting

* update IB rearrange condition

* CUR-912 Shared flag no longer required on playlist project for PlaylistController->loadLti action (#231)

* CUR-916 Refined author search in the lti external tool search form (#232)

* Bugfix/cur 916 changes to lti search (#234)

* Small fix for author search.