### PR TITLE
fixed some typo mistakes mention on tickets CUR-1015,CUR-1016

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -94,7 +94,7 @@ class TeamController extends Controller
     }
 
     /**
-     * Invite Team Member
+     * Invite Team Member on Team Creation
      *
      * Invite a team member while creating a team.
      *

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -366,9 +366,9 @@ class UserController extends Controller
     }
 
     /**
-     * Read All Notification
+     * Read All Notifications
      *
-     * Read all notification of the specified user.
+     * Read all notifications of the specified user.
      *
      * @responseFile responses/notifications/notifications.json
      *


### PR DESCRIPTION
The API content "Read All Notification" is spelling mistake has been changed to  "Read All Notifications"
(API Doc) The content "Invite Team Member" is not clear not changed to "Invite Team Member on Team Creation"