### PR TITLE
[CUR-2312] Shared playlist apis

### DIFF
--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -388,6 +388,7 @@ class PlaylistController extends Controller
     {
         $this->playlistRepository->populateOrderNumber();
     }
+
     /**
      * Share playlist
      *
@@ -427,6 +428,7 @@ class PlaylistController extends Controller
             'errors' => ['Failed to share playlist.'],
         ], 500);
     }
+
     /**
      * Remove Share playlist
      *
@@ -536,4 +538,5 @@ class PlaylistController extends Controller
             'errors' => ['No shareable Playlist found.'],
         ], 400);
     }
+    
 }

--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -18,6 +18,7 @@ use App\Repositories\Project\ProjectRepositoryInterface;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Config;
 
 /**
  * @group 4. Playlist
@@ -405,7 +406,8 @@ class PlaylistController extends Controller
      *   ]
      * }
      *
-     * @param playlist $playlist
+     * @param Playlist $playlist
+     * @param Project $project
      * @return Response
      */
     public function share(Project $project, Playlist $playlist)
@@ -445,7 +447,8 @@ class PlaylistController extends Controller
      *   ]
      * }
      *
-     * @param playlist $playlist
+     * @param Playlist $playlist
+     * @param Project $project
      * @return Response
      */
     public function removeShare(Project $project, Playlist $playlist)
@@ -486,13 +489,14 @@ class PlaylistController extends Controller
      *   ]
      * }
      *
+     * @param Playlist $playlist
      * @param Project $project
      * @return Response
      */
     public function loadSharedPlaylist(Project $project, Playlist $playlist)
     {
         // 3 is for indexing approved - see Project Model @indexing property
-        if ($project->shared || ($project->indexing === 3)) {
+        if ($project->shared || ($project->indexing === Config::get('constants.indexing-approved'))) {
             if($playlist->shared){
                 return response([
                     'playlist' => new PlaylistResource($this->playlistRepository->loadSharedPlaylist($project, $playlist)),
@@ -508,11 +512,9 @@ class PlaylistController extends Controller
     /**
      * Get All Shared Playlists of a Project
      *
-     * Get the specified shared playlists detail.
+     * Get the list of shared playlists detail.
      *
      * @urlParam project required The Id of a project Example: 1
-     * 
-     * @urlParam project required The Id of a playlist Example: 1
      *
      * @responseFile responses/playlist/playlist.json
      *
@@ -522,13 +524,14 @@ class PlaylistController extends Controller
      *   ]
      * }
      *
+     * @param Playlist $playlist
      * @param Project $project
      * @return Response
      */
     public function allSharedPlaylists(Project $project, Playlist $playlist)
     {
         // 3 is for indexing approved - see Project Model @indexing property
-        if ($project->shared || ($project->indexing === 3)) {
+        if ($project->shared || ($project->indexing === Config::get('constants.indexing-approved'))) {
                 return response([
                     'playlist' => PlaylistResource::collection($this->playlistRepository->allSharedPlaylists($project, $playlist)),
                 ], 200);

--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -466,4 +466,74 @@ class PlaylistController extends Controller
             'errors' => ['Failed to stop share playlist.'],
         ], 500);
     }
+    
+    /**
+     * Get Shared Playlist
+     *
+     * Get the specified shared playlist detail.
+     *
+     * @urlParam project required The Id of a project Example: 1
+     * 
+     * @urlParam project required The Id of a playlist Example: 1
+     *
+     * @responseFile responses/playlist/playlist.json
+     *
+     * @response 400 {
+     *   "errors": [
+     *     "No shareable Playlist found."
+     *   ]
+     * }
+     *
+     * @param Project $project
+     * @return Response
+     */
+    public function loadSharedPlaylist(Project $project, Playlist $playlist)
+    {
+        // 3 is for indexing approved - see Project Model @indexing property
+        if ($project->shared || ($project->indexing === 3)) {
+            if($playlist->shared){
+                return response([
+                    'playlist' => $this->playlistRepository->loadSharedPlaylist($project, $playlist),
+                ], 200);
+            }
+        }
+
+        return response([
+            'errors' => ['No shareable Playlist found.'],
+        ], 400);
+    }
+
+    /**
+     * Get All Shared Playlists of a Project
+     *
+     * Get the specified shared playlists detail.
+     *
+     * @urlParam project required The Id of a project Example: 1
+     * 
+     * @urlParam project required The Id of a playlist Example: 1
+     *
+     * @responseFile responses/playlist/playlist.json
+     *
+     * @response 400 {
+     *   "errors": [
+     *     "No shareable Playlist found."
+     *   ]
+     * }
+     *
+     * @param Project $project
+     * @return Response
+     */
+    public function allSharedPlaylists(Project $project, Playlist $playlist)
+    {
+        // 3 is for indexing approved - see Project Model @indexing property
+        if ($project->shared || ($project->indexing === 3)) {
+                return response([
+                    'project' => $this->playlistRepository->allSharedPlaylists($project, $playlist),
+                ], 200);
+        }
+
+        return response([
+            'errors' => ['No shareable Playlist found.'],
+        ], 400);
+    }
 }

--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -468,7 +468,7 @@ class PlaylistController extends Controller
         }
 
         return response([
-            'errors' => ['Failed to stop share playlist.'],
+            'errors' => ['Failed to remove share playlist.'],
         ], 500);
     }
     
@@ -478,7 +478,6 @@ class PlaylistController extends Controller
      * Get the specified shared playlist detail.
      *
      * @urlParam project required The Id of a project Example: 1
-     * 
      * @urlParam project required The Id of a playlist Example: 1
      *
      * @responseFile responses/playlist/playlist.json

--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -495,7 +495,7 @@ class PlaylistController extends Controller
         if ($project->shared || ($project->indexing === 3)) {
             if($playlist->shared){
                 return response([
-                    'playlist' => $this->playlistRepository->loadSharedPlaylist($project, $playlist),
+                    'playlist' => new PlaylistResource($this->playlistRepository->loadSharedPlaylist($project, $playlist)),
                 ], 200);
             }
         }
@@ -530,7 +530,7 @@ class PlaylistController extends Controller
         // 3 is for indexing approved - see Project Model @indexing property
         if ($project->shared || ($project->indexing === 3)) {
                 return response([
-                    'project' => $this->playlistRepository->allSharedPlaylists($project, $playlist),
+                    'playlist' => PlaylistResource::collection($this->playlistRepository->allSharedPlaylists($project, $playlist)),
                 ], 200);
         }
 
@@ -538,5 +538,5 @@ class PlaylistController extends Controller
             'errors' => ['No shareable Playlist found.'],
         ], 400);
     }
-    
+
 }

--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -388,4 +388,82 @@ class PlaylistController extends Controller
     {
         $this->playlistRepository->populateOrderNumber();
     }
+    /**
+     * Share playlist
+     *
+     * Share the specified playlist of a user.
+     *
+     * @urlParam playlist required The Id of a playlist Example: 1
+     * @urlParam project required The Id of a project Example: 1
+     *
+     * @responseFile responses/playlist/playlist.json
+     *
+     * @response 500 {
+     *   "errors": [
+     *     "Failed to share playlist."
+     *   ]
+     * }
+     *
+     * @param playlist $playlist
+     * @return Response
+     */
+    public function share(Project $project, Playlist $playlist)
+    {
+        $this->authorize('clone', [Playlist::class, $project]);
+
+        $is_updated = $this->playlistRepository->update([
+            'shared' => true,
+        ], $playlist->id);
+
+        if ($is_updated) {
+            $updated_playlist = new playlistResource($this->playlistRepository->find($playlist->id));
+
+            return response([
+                'playlist' => $updated_playlist,
+            ], 200);
+        }
+
+        return response([
+            'errors' => ['Failed to share playlist.'],
+        ], 500);
+    }
+    /**
+     * Remove Share playlist
+     *
+     * Remove Share the specified playlist of a user.
+     *
+     * @urlParam playlist required The Id of a playlist Example: 1
+     * @urlParam project required The Id of a project Example: 1
+     *
+     * @responseFile responses/playlist/playlist.json
+     *
+     * @response 500 {
+     *   "errors": [
+     *     "Failed to remove share playlist."
+     *   ]
+     * }
+     *
+     * @param playlist $playlist
+     * @return Response
+     */
+    public function removeShare(Project $project, Playlist $playlist)
+    {
+        $this->authorize('clone', [Playlist::class, $project]);
+
+        $is_updated = $this->playlistRepository->update([
+            'shared' => false,
+        ], $playlist->id);
+
+        if ($is_updated) {
+            $updated_playlist = new playlistResource($this->playlistRepository->find($playlist->id));
+
+            return response([
+                'playlist' => $updated_playlist,
+            ], 200);
+        }
+
+        return response([
+            'errors' => ['Failed to stop share playlist.'],
+        ], 500);
+    }
 }

--- a/app/Http/Resources/V1/PlaylistResource.php
+++ b/app/Http/Resources/V1/PlaylistResource.php
@@ -22,6 +22,7 @@ class PlaylistResource extends JsonResource
             'title' => $this->title,
             'order' => $this->order,
             'project_id' => $this->project_id,
+            'shared' => $this->shared,
             'project' => new PlaylistProjectResource($this->project),
             'activities' => ActivityResource::collection($this->activities->sortBy('order')),
             'created_at' => $this->created_at,

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -21,6 +21,7 @@ class Playlist extends Model
     protected $fillable = [
         'title',
         'project_id',
+        'shared',
         'order'
     ];
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -95,6 +95,14 @@ class Project extends Model
     }
 
     /**
+     * Get the single playlist for the project
+     */
+    public function singlePlaylist()
+    {
+        return $this->hasOne('App\Models\Playlist', 'project_id');
+    }
+
+    /**
      * Get the organization that owns the project.
      */
     public function organization()

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -252,9 +252,14 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
             ->where('project_id', $project->id)
             ->with('project');
 
+        /**
+         * if project is indexed then all shared/unshared playlists will be visible.
+         * if not indexed then only shared playlists will be visible
+         */
         $playlists->when($project->indexing != 3, function ($q){
             return $q->where('shared', true);
-        });    
+        }); 
+           
         return $playlists = $playlists->get();
     }
 

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -223,6 +223,7 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
             }
         }
     }
+
     /**
      * To show single shared playlist
      *
@@ -268,7 +269,7 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
             return $proj;
         }
 
-        /**
+    /**
      * To show all shared playlist
      *
      * @param $authUser
@@ -324,7 +325,7 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
             }
             $proj["playlists"][] = $plist;
         }
-
         return $proj;
-        }
+    }
+    
 }

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -228,35 +228,30 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
     /**
      * To show single shared playlist
      *
-     * @param $authUser
-     * @param Project $project
+     * @param Playlist $playlist
      * @throws GeneralException
      */
-    public function loadSharedPlaylist(Project $project, Playlist $playlist){
-
+    public function loadSharedPlaylist(Playlist $playlist)
+    {
         return $this->model::whereHas('project')
             ->where('id', $playlist->id)
             ->with('project')
             ->first();
-        }
+    }
 
     /**
      * To show all shared playlist
      *
-     * @param $authUser
      * @param Project $project
      * @throws GeneralException
      */
-    public function allSharedPlaylists(Project $project){
-
+    public function allSharedPlaylists(Project $project)
+    {
         $playlists = $this->model::whereHas('project')
             ->where('project_id', $project->id)
             ->with('project');
 
-        /**
-         * if project is indexed then all shared/unshared playlists will be visible.
-         * if not indexed then only shared playlists will be visible
-         */
+        //if project is indexed then all shared/unshared playlists will be visible. if not indexed then only shared playlists will be visible
         $playlists->when($project->indexing != Config::get('constants.indexing-approved'), function ($q){
             return $q->where('shared', true);
         }); 

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -247,7 +247,6 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
                 $oneplaylist->shared = $playlist['shared'] ?? false;
                 $oneplaylist->created_at = $playlist['created_at'];
                 $oneplaylist->updated_at = $playlist['updated_at'];
-                $oneplaylist->project = $playlist->project;
                 $oneplaylist->activities = [];
     
                 foreach ($playlist['activities'] as $activity) {

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -13,6 +13,7 @@ use App\Repositories\Activity\ActivityRepositoryInterface;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use stdClass;
 
 class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInterface
@@ -256,10 +257,10 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
          * if project is indexed then all shared/unshared playlists will be visible.
          * if not indexed then only shared playlists will be visible
          */
-        $playlists->when($project->indexing != 3, function ($q){
+        $playlists->when($project->indexing != Config::get('constants.indexing-approved'), function ($q){
             return $q->where('shared', true);
         }); 
-           
+
         return $playlists = $playlists->get();
     }
 

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -286,7 +286,6 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
                 $query->orderBy('order');
             }])
             ->first();
-
         $proj = [];
         $proj["id"] = $project['id'];
         $proj["name"] = $project['name'];
@@ -327,5 +326,5 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
         }
         return $proj;
     }
-    
+
 }

--- a/app/Repositories/Playlist/PlaylistRepository.php
+++ b/app/Repositories/Playlist/PlaylistRepository.php
@@ -13,6 +13,7 @@ use App\Repositories\Activity\ActivityRepositoryInterface;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\Request;
+use stdClass;
 
 class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInterface
 {
@@ -222,4 +223,109 @@ class PlaylistRepository extends BaseRepository implements PlaylistRepositoryInt
             }
         }
     }
+    /**
+     * To show single shared playlist
+     *
+     * @param $authUser
+     * @param Project $project
+     * @throws GeneralException
+     */
+    public function loadSharedPlaylist(Project $project, Playlist $playlist){
+
+        $playlist = Playlist::where('id', $playlist->id)
+                ->with([
+                    'activities' => function ($query) {
+                    $query->orderBy('order');
+                }])
+                ->first();
+    
+            $oneplaylist = new stdClass();
+                
+                $oneplaylist->id = $playlist['id'];
+                $oneplaylist->title = $playlist['title'];
+                $oneplaylist->project_id = $playlist->project->id;
+                $oneplaylist->shared = $playlist['shared'] ?? false;
+                $oneplaylist->created_at = $playlist['created_at'];
+                $oneplaylist->updated_at = $playlist['updated_at'];
+                $oneplaylist->project = $playlist->project;
+                $oneplaylist->activities = [];
+    
+                foreach ($playlist['activities'] as $activity) {
+                    $h5pContent = \DB::table('h5p_contents')
+                        ->select(['h5p_contents.title', 'h5p_libraries.name as library_name'])
+                        ->where(['h5p_contents.id' => $activity->h5p_content_id])
+                        ->join('h5p_libraries', 'h5p_contents.library_id', '=', 'h5p_libraries.id')->first();
+    
+                    $plistActivity = [];
+                    $plistActivity['id'] = $activity->id;
+                    $plistActivity['type'] = $activity->type;
+                    $plistActivity['title'] = $activity->title;
+                    $plistActivity['library_name'] = $h5pContent ? $h5pContent->library_name : null;
+                    $plistActivity['thumb_url'] = $activity->thumb_url;
+                    $oneplaylist->activities[] = $plistActivity;
+                }
+                $proj = $oneplaylist;
+    
+            return $proj;
+        }
+
+        /**
+     * To show all shared playlist
+     *
+     * @param $authUser
+     * @param Project $project
+     * @throws GeneralException
+     */
+    public function allSharedPlaylists(Project $project, Playlist $playlist){
+
+        $project = Project::where(['id' => $project->id])
+            ->with(['playlists' => function ($query) {
+                $query->where('shared', true)->orderBy('order');
+            },
+            'playlists.activities' => function ($query) {
+                $query->orderBy('order');
+            }])
+            ->first();
+
+        $proj = [];
+        $proj["id"] = $project['id'];
+        $proj["name"] = $project['name'];
+        $proj["description"] = $project['description'];
+        $proj["thumb_url"] = $project['thumb_url'];
+        $proj["shared"] = $project['shared'] ?? false;
+        $proj["indexing"] = $project['indexing'];
+        $proj["indexing_text"] = $project['indexing_text'];
+        $proj["created_at"] = $project['created_at'];
+        $proj["updated_at"] = $project['updated_at'];
+
+        $proj["playlists"] = [];
+        foreach ($project['playlists'] as $playlist) {
+            $plist = [];
+            $plist["id"] = $playlist['id'];
+            $plist["title"] = $playlist['title'];
+            $plist["project_id"] = $playlist->project->id;
+            $plist["shared"] = $playlist->shared;
+            $plist["created_at"] = $playlist['created_at'];
+            $plist["updated_at"] = $playlist['updated_at'];
+            $plist['activities'] = [];
+
+            foreach ($playlist['activities'] as $activity) {
+                $h5pContent = \DB::table('h5p_contents')
+                    ->select(['h5p_contents.title', 'h5p_libraries.name as library_name'])
+                    ->where(['h5p_contents.id' => $activity->h5p_content_id])
+                    ->join('h5p_libraries', 'h5p_contents.library_id', '=', 'h5p_libraries.id')->first();
+
+                $plistActivity = [];
+                $plistActivity['id'] = $activity->id;
+                $plistActivity['type'] = $activity->type;
+                $plistActivity['title'] = $activity->title;
+                $plistActivity['library_name'] = $h5pContent ? $h5pContent->library_name : null;
+                $plistActivity['thumb_url'] = $activity->thumb_url;
+                $plist['activities'][] = $plistActivity;
+            }
+            $proj["playlists"][] = $plist;
+        }
+
+        return $proj;
+        }
 }

--- a/database/migrations/2021_11_19_102949_add_shared_to_playlists_table.php
+++ b/database/migrations/2021_11_19_102949_add_shared_to_playlists_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSharedToPlaylistsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->boolean('shared')->nullable()->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn(['shared']);
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -114,6 +114,9 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
         // playlist share toggle
         Route::get('projects/{project}/playlists/{playlist}/share', 'PlaylistController@share');
         Route::get('projects/{project}/playlists/{playlist}/remove-share', 'PlaylistController@removeShare');
+
+        Route::get('projects/{project}/playlists/{playlist}/load-shared-playlist', 'PlaylistController@loadSharedPlaylist');
+        Route::get('projects/{project}/shared-playlists', 'PlaylistController@allSharedPlaylists');
         
         Route::post('playlists/{playlist}/activities/{activity}/clone', 'ActivityController@clone');
         Route::post('activities/upload-thumb', 'ActivityController@uploadThumb');

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,11 +35,11 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
     Route::get('activities/{activity}/log-view', 'MetricsController@activityLogView')->name('metrics.activity-log');
     Route::get('playlists/{playlist}/log-view', 'MetricsController@playlistLogView')->name('metrics.playlist-log');
     Route::get('projects/{project}/log-view', 'MetricsController@projectLogView')->name('metrics.project-log');
-
+    
     Route::get('organization-types', 'OrganizationTypesController@index');
-
+    
     Route::get('organization/get-by-domain', 'OrganizationController@getByDomain')->name('organization.get-by-domain');
-
+    
     Route::middleware(['auth:api', 'verified'])->group(function () {
         Route::get('users/organizations', 'UserController@getOrganizations');
         Route::post('subscribe', 'UserController@subscribe');
@@ -57,7 +57,7 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
         Route::apiResource('users', 'UserController')->only([
             'index', 'show', 'update', 'destroy'
         ]);
-
+        
         // Teams
         Route::post('teams/invite', 'TeamController@inviteTeamMember');
         Route::post('teams/{team}/invite-member', 'TeamController@inviteMember');
@@ -72,7 +72,7 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
         Route::get('suborganization/{suborganization}/team/{team}/team-permissions', 'TeamController@getUserTeamPermissions');
         Route::put('suborganization/{suborganization}/team/{team}/update-team-member-role', 'TeamController@updateTeamMemberRole');
         Route::apiResource('suborganization.teams', 'TeamController');
-
+        
         // Groups
         Route::post('groups/invite', 'GroupController@inviteGroupMember');
         Route::post('groups/{group}/invite-member', 'GroupController@inviteMember');
@@ -84,8 +84,8 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
         Route::post('groups/{group}/projects/{project}/remove-member', 'GroupController@removeMemberFromProject');
         Route::get('suborganization/{suborganization}/get-groups', 'GroupController@getOrgGroups');
         Route::apiResource('suborganization.groups', 'GroupController');
-
-
+        
+        
         Route::post('suborganization/{suborganization}/projects/upload-thumb', 'ProjectController@uploadThumb');
         Route::get('suborganization/{suborganization}/projects/recent', 'ProjectController@recent');
         Route::get('suborganization/{suborganization}/projects/default', 'ProjectController@default');
@@ -100,17 +100,21 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
         Route::post('suborganization/{suborganization}/projects/{project}/export', 'ProjectController@exportProject');
         Route::post('suborganization/{suborganization}/projects/{project}/export-noovo', 'ProjectController@exportNoovoProject');
         Route::post('suborganization/{suborganization}/projects/import', 'ProjectController@importProject');
-
-
+        
+        
         Route::post('suborganization/{suborganization}/projects/{project}/remove-share', 'ProjectController@removeShare');
         Route::post('suborganization/{suborganization}/projects/{project}/favorite', 'ProjectController@favorite');
         Route::get('suborganization/{suborganization}/team-projects', 'ProjectController@getTeamProjects');
         Route::apiResource('suborganization.projects', 'ProjectController');
-
+        
         Route::post('projects/{project}/playlists/reorder', 'PlaylistController@reorder');
         Route::post('projects/{project}/playlists/{playlist}/clone', 'PlaylistController@clone');
         Route::apiResource('projects.playlists', 'PlaylistController');
-
+        
+        // playlist share toggle
+        Route::get('projects/{project}/playlists/{playlist}/share', 'PlaylistController@share');
+        Route::get('projects/{project}/playlists/{playlist}/remove-share', 'PlaylistController@removeShare');
+        
         Route::post('playlists/{playlist}/activities/{activity}/clone', 'ActivityController@clone');
         Route::post('activities/upload-thumb', 'ActivityController@uploadThumb');
         Route::get('activities/{activity}/share', 'ActivityController@share');
@@ -121,22 +125,22 @@ Route::group(['prefix' => 'v1', 'namespace' => 'Api\V1'], function () {
         Route::get('activities/{activity}/h5p-resource-settings', 'ActivityController@getH5pResourceSettings');
         Route::get('activities/{activity}/h5p-resource-settings-open', 'ActivityController@getH5pResourceSettingsOpen');
         Route::apiResource('playlists.activities', 'ActivityController');
-
+        
         Route::get('activity-layouts', 'ActivityItemController@activityLayouts');
         Route::post('get-whiteboard', 'WhiteboardController@getWhiteboard');
-
+        
         Route::get('activity-types/{activityType}/items', 'ActivityTypeController@items');
         Route::apiResource('activity-types', 'ActivityTypeController');
-
+        
         Route::apiResource('activity-items', 'ActivityItemController');
-
+        
         Route::get('users/{user}/metrics', 'UserMetricsController@show')->name('metrics.user');
         Route::get('users/{user}/membership', 'UserMembershipController@show')->name('membership.show');
-
+        
         Route::get('h5p/settings', 'H5pController@create');
         Route::get('h5p/activity/{activity}', 'H5pController@showByActivity');
         Route::apiResource('h5p', 'H5pController');
-
+        
         Route::group(['prefix' => 'h5p'], function () {
             // H5P Ajax calls
             Route::match(['GET', 'POST'], 'ajax/libraries', '\Djoudi\LaravelH5p\Http\Controllers\AjaxController@libraries')->name('h5p.ajax.libraries');


### PR DESCRIPTION
Adds the following routes:

        // playlist share toggle
        Route::get('projects/{project}/playlists/{playlist}/share', 'PlaylistController@share');
        Route::get('projects/{project}/playlists/{playlist}/remove-share', 'PlaylistController@removeShare');

        Route::get('projects/{project}/playlists/{playlist}/load-shared-playlist', 'PlaylistController@loadSharedPlaylist');
        Route::get('projects/{project}/shared-playlists', 'PlaylistController@allSharedPlaylists');
        
        
Has one migration:
database/migrations/2021_11_19_102949_add_shared_to_playlists_table.php