### PR TITLE
CUR-3133: Permissions related observations

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -115,7 +115,6 @@ class SearchController extends Controller
         $data = $searchRequest->validated();
 
         $organization = $this->organizationRepository->find($data['organization_id']);
-        $this->authorize('advanceSearch', $organization);
 
         $data['organizationIds'] = [$data['organization_id']];
         $data['orgObj'] = $organization;
@@ -169,9 +168,6 @@ class SearchController extends Controller
     public function dashboard(SearchRequest $searchRequest)
     {
         $data = $searchRequest->validated();
-
-        $organization = $this->organizationRepository->find($data['organization_id']);
-        $this->authorize('dashboardSearch', $organization);
 
         $data['userIds'] = [auth()->user()->id];
 

--- a/app/Policies/OrganizationPolicy.php
+++ b/app/Policies/OrganizationPolicy.php
@@ -191,30 +191,6 @@ class OrganizationPolicy
     }
 
     /**
-     * Determine whether the user can do advance search in suborganization.
-     *
-     * @param  User  $user
-     * @param  Organization  $organization
-     * @return mixed
-     */
-    public function advanceSearch(User $user, Organization $organization)
-    {
-        return $user->hasPermissionTo('search:advance', $organization);
-    }
-
-    /**
-     * Determine whether the user can do dashboard search in suborganization.
-     *
-     * @param  User  $user
-     * @param  Organization  $organization
-     * @return mixed
-     */
-    public function dashboardSearch(User $user, Organization $organization)
-    {
-        return $user->hasPermissionTo('search:dashboard', $organization);
-    }
-
-    /**
      * Determine whether the user can restore the model.
      *
      * @param  \App\User  $user

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -221,7 +221,7 @@ class ProjectPolicy
      */
     public function export(User $user, Organization $suborganization)
     {
-        return $user->hasPermissionTo('project:export', $suborganization);
+        return $user->hasPermissionTo('organization:export-project', $suborganization);
     }
 
     /**
@@ -233,7 +233,7 @@ class ProjectPolicy
      */
     public function import(User $user, Organization $suborganization)
     {
-        return $user->hasPermissionTo('project:import', $suborganization);
+        return $user->hasPermissionTo('organization:import-project', $suborganization);
     }
 
     /**
@@ -246,10 +246,6 @@ class ProjectPolicy
      */
     public function searchPreview(User $user, Project $project, Organization $suborganization)
     {
-        if (!($user->hasPermissionTo('search:advance', $suborganization) || $user->hasPermissionTo('search:dashboard', $suborganization))) {
-            return false;
-        }
-
         if ($user->hasPermissionTo('organization:view', $suborganization)) {
             return true;
         }

--- a/database/migrations/2022_02_01_080228_remove_search_project_export_import_organization_permission_types_table.php
+++ b/database/migrations/2022_02_01_080228_remove_search_project_export_import_organization_permission_types_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveSearchProjectExportImportOrganizationPermissionTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        \Artisan::call('db:seed', [
+            '--class' => OrganizationPermissionTypeRemovalSeeder::class
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/seeds/OrganizationPermissionTypeRemovalSeeder.php
+++ b/database/seeds/OrganizationPermissionTypeRemovalSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class OrganizationPermissionTypeRemovalSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $permissionsToRemove = ['project:export', 'project:import', 'search:advance', 'search:dashboard'];
+
+        $permissionsToRemoveIds = DB::table('organization_permission_types')->whereIn('name', $permissionsToRemove)->pluck('id');
+
+        return DB::transaction(function () use ($permissionsToRemoveIds) {
+            DB::table('organization_role_permissions')->whereIn('organization_permission_type_id', $permissionsToRemoveIds)->delete();
+
+            DB::table('organization_permission_types')->whereIn('id', $permissionsToRemoveIds)->delete();
+        });
+    }
+}


### PR DESCRIPTION
Removed the permissions for project:export, project:import, search:advance and search:dashboard.
Removed the authorization policy checks for search:advance and search:dashboard.
Replaced the authorization policy checks for project:export and project:import with organization:export-project and organization:import-project.