### PR TITLE
CUR-3303: Added  “'--force' => true“ to BrightCove migration

### DIFF
--- a/database/migrations/2022_03_01_153314_add_organization_admin_brightcove_permission_type_seeder_with_force.php
+++ b/database/migrations/2022_03_01_153314_add_organization_admin_brightcove_permission_type_seeder_with_force.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 
-class AddOrganizationAdminBrightcovePermissionTypeSeeder extends Migration
+class AddOrganizationAdminBrightcovePermissionTypeSeederWithForce extends Migration
 {
     /**
      * Run the migrations.
@@ -12,7 +12,8 @@ class AddOrganizationAdminBrightcovePermissionTypeSeeder extends Migration
     public function up()
     {
         \Artisan::call('db:seed', [
-            '--class' => OrganizationAdminPanelBrightCovePermissionTypeSeeder::class
+            '--class' => OrganizationAdminPanelBrightCovePermissionTypeSeeder::class,
+            '--force' => true
         ]);
     }
 


### PR DESCRIPTION
Added “'--force' => true“ to new migration 
to run seeder "OrganizationAdminPanelBrightCovePermissionTypeSeeder" on server 
like stage that have prod env

Deleted the old migration "2022_01_26_114513_add_organization_admin_brightcove_permission_type_seeder.php"
