### PR TITLE
CUR-3560  Remove SendDailyUsage from Kernel

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -28,7 +28,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         // $schedule->command(SendDailyUsage::class)->dailyAt('0:00');
-        $schedule->command(SendDailyUsage::class)->everyFourHours();
+        // $schedule->command(SendDailyUsage::class)->everyFourHours();
         $schedule->command(PushNoovo::class)->everyMinute()->withoutOverlapping()->runInBackground();
         $schedule->command(DeleteExportedProjects::class)->daily()->runInBackground();
     }


### PR DESCRIPTION
Removed "SendDailyUsage" command from Kernel schedule on staging.