### PR TITLE
CUR-3484: As an Author I can pick the Library scope for an Independent Activity just like I can on a project

### DIFF
--- a/app/Http/Requests/V1/IndependentActivityEditRequest.php
+++ b/app/Http/Requests/V1/IndependentActivityEditRequest.php
@@ -41,6 +41,7 @@ class IndependentActivityEditRequest extends FormRequest
             'author_tag_id.*' => 'integer|distinct|exists:author_tags,id,deleted_at,NULL',
             'source_type' => 'nullable|string',
             'source_url' => 'nullable|string',
+            'organization_visibility_type_id' => 'required|integer|exists:organization_visibility_types,id',
         ];
     }
 }

--- a/app/Http/Resources/V1/IndependentActivityResource.php
+++ b/app/Http/Resources/V1/IndependentActivityResource.php
@@ -32,6 +32,11 @@ class IndependentActivityResource extends JsonResource
             'author_tags' => AuthorTagResource::collection($this->authorTags),
             'source_type' => $this->source_type,
             'source_url' => $this->source_url,
+            'organization_visibility_type_id' => $this->organization_visibility_type_id,
+            'status' => $this->status,
+            'status_text' => $this->status_text,
+            'indexing' => $this->indexing,
+            'indexing_text' => $this->indexing_text,
         ];
 
         // Feature added after the fact for optimization

--- a/app/Models/IndependentActivity.php
+++ b/app/Models/IndependentActivity.php
@@ -39,6 +39,12 @@ class IndependentActivity extends Model
     ];
 
     /**
+     * STATIC PROPERTIES FOR MAPPING THE DATABASE COLUMN VALUES
+     */
+    public static $status = [1 => 'DRAFT' , 2 => 'FINISHED'];
+    public static $indexing = [1 => 'REQUESTED', 2 => 'NOT APPROVED', 3 => 'APPROVED'];
+
+    /**
      * Cascade on delete the IndependentActivity
      */
     public static function boot()
@@ -130,5 +136,21 @@ class IndependentActivity extends Model
     public function organization()
     {
         return $this->belongsTo('App\Models\Organization');
+    }
+
+    /**
+     * Maps the indexing integer value and returns the text
+     * @return string|null
+     */
+    public function getIndexingTextAttribute(){
+        return self::$indexing[$this->indexing] ?? 'NOT REQUESTED';
+    }
+
+    /**
+     * Maps the status value and returns the text
+     * @return string|null
+     */
+    public function getStatusTextAttribute(){
+        return self::$status[$this->status] ?? null;
     }
 }

--- a/app/Repositories/IndependentActivity/IndependentActivityRepositoryInterface.php
+++ b/app/Repositories/IndependentActivity/IndependentActivityRepositoryInterface.php
@@ -34,4 +34,23 @@ interface IndependentActivityRepositoryInterface extends EloquentRepositoryInter
      * @return int
      */
     public function getOrder($organizationId);
+
+    /**
+     * Create model in storage
+     *
+     * @param $authenticatedUser
+     * @param $suborganization
+     * @param $data
+     * @return Model
+     */
+    public function createIndependentActivity($authenticatedUser, $suborganization, $data);
+
+    /**
+     * Get user independent activity ids in org
+     *
+     * @param $authenticatedUser
+     * @param $organization
+     * @return array
+     */
+    public function getUserIndependentActivityIdsInOrganization($authenticatedUser, $organization);
 }

--- a/app/User.php
+++ b/app/User.php
@@ -305,4 +305,12 @@ class User extends Authenticatable implements MustVerifyEmail
         $userRepository = resolve(UserRepositoryInterface::class);
         return $userRepository->hasTeamPermissionTo($this, $permission, $team);
     }
+
+    /**
+     * Get the independent activities for the user.
+     */
+    public function independentActivities()
+    {
+        return $this->hasMany('App\Models\IndependentActivity');
+    }
 }

--- a/database/migrations/2022_04_11_150324_create_independent_activities_table.php
+++ b/database/migrations/2022_04_11_150324_create_independent_activities_table.php
@@ -24,14 +24,9 @@ class CreateIndependentActivitiesTable extends Migration
             $table->unsignedBigInteger('h5p_content_id')->nullable();
             $table->foreign('h5p_content_id')->references('id')->on('h5p_contents');
             $table->string('thumb_url')->nullable()->default(null);
-            $table->string('subject_id')->nullable()->default(null);
-            $table->string('education_level_id')->nullable()->default(null);
-            $table->unsignedBigInteger('user_id')->nullable();
-            $table->foreign('user_id')->references('id')->on('users');
-            $table->unsignedBigInteger('organization_id')->nullable()->default(null);
-            $table->foreign('organization_id')->references('id')->on('organizations');
-            $table->unsignedBigInteger('organization_visibility_type_id')->nullable()->default(null);
-            $table->foreign('organization_visibility_type_id')->references('id')->on('organization_visibility_types');
+            $table->foreignId('user_id')->constrained();
+            $table->foreignId('organization_id')->constrained();
+            $table->foreignId('organization_visibility_type_id')->constrained();
             $table->mediumText('description')->nullable();
             $table->string('source_type')->nullable();
             $table->string('source_url')->nullable();

--- a/database/migrations/2022_04_25_141852_create_independent_activity_subject_table.php
+++ b/database/migrations/2022_04_25_141852_create_independent_activity_subject_table.php
@@ -15,10 +15,8 @@ class CreateIndependentActivitySubjectTable extends Migration
     {
         Schema::create('independent_activity_subject', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('independent_activity_id');
-            $table->foreign('independent_activity_id')->references('id')->on('independent_activities');
-            $table->unsignedBigInteger('subject_id');
-            $table->foreign('subject_id')->references('id')->on('subjects');
+            $table->foreignId('independent_activity_id')->constrained();
+            $table->foreignId('subject_id')->constrained();
             $table->unique(['independent_activity_id', 'subject_id']);
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2022_04_25_141912_create_independent_activity_education_level_table.php
+++ b/database/migrations/2022_04_25_141912_create_independent_activity_education_level_table.php
@@ -15,10 +15,8 @@ class CreateIndependentActivityEducationLevelTable extends Migration
     {
         Schema::create('independent_activity_education_level', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('independent_activity_id');
-            $table->foreign('independent_activity_id')->references('id')->on('independent_activities');
-            $table->unsignedBigInteger('education_level_id');
-            $table->foreign('education_level_id')->references('id')->on('education_levels');
+            $table->foreignId('independent_activity_id')->constrained();
+            $table->foreignId('education_level_id')->constrained();
             $table->unique(['independent_activity_id', 'education_level_id']);
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2022_04_25_141921_create_independent_activity_author_tag_table.php
+++ b/database/migrations/2022_04_25_141921_create_independent_activity_author_tag_table.php
@@ -15,10 +15,8 @@ class CreateIndependentActivityAuthorTagTable extends Migration
     {
         Schema::create('independent_activity_author_tag', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('independent_activity_id');
-            $table->foreign('independent_activity_id')->references('id')->on('independent_activities');
-            $table->unsignedBigInteger('author_tag_id');
-            $table->foreign('author_tag_id')->references('id')->on('author_tags');
+            $table->foreignId('independent_activity_id')->constrained();
+            $table->foreignId('author_tag_id')->constrained();
             $table->unique(['independent_activity_id', 'author_tag_id']);
             $table->timestamps();
             $table->softDeletes();


### PR DESCRIPTION
Refactored API for create independent activity, updated logic for ordering and moved to Repository.
Created API for update independent activity, updated resource, validation, logic for organization visibility.
Updated migrations, removed obsolete subject and education level ids, added one to many relation between user and independent activity.