### PR TITLE
[CUR-3718] remove duplication records of role types and its associations

### DIFF
--- a/database/migrations/2022_05_20_564513_create_composite_unique_index_on_organization_role_types_table.php
+++ b/database/migrations/2022_05_20_564513_create_composite_unique_index_on_organization_role_types_table.php
@@ -59,7 +59,7 @@ class CreateCompositeUniqueIndexOnOrganizationRoleTypesTable extends Migration
                                         AND organization_id = " . $organization_id . "
                                     ");
 
-                                $res = DB::table("organization_user_roles")->insertOrIgnore(
+                                DB::table("organization_user_roles")->insertOrIgnore(
                                     [
                                         'organization_id' => $organization_id,
                                         'user_id' => $userRole->user_id,

--- a/database/migrations/2022_05_20_564513_create_composite_unique_index_on_organization_role_types_table.php
+++ b/database/migrations/2022_05_20_564513_create_composite_unique_index_on_organization_role_types_table.php
@@ -1,0 +1,128 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCompositeUniqueIndexOnOrganizationRoleTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // this algorithm is using for to delete duplicated role types and their associated content
+        return DB::transaction(function () {
+
+            $organizations = DB::table('organizations')->pluck('id');
+            $allDuplicatedRoleTypes = [];
+
+            foreach ($organizations as $organization_id) {
+                $duplicatedRoleTypes = DB::select("SELECT t1.id, t1.name
+                                            FROM organization_role_types AS t1,
+                                            organization_role_types AS t2
+                                            WHERE t1.name = t2.name
+                                            AND t1.id > t2.id
+                                            AND t1.organization_id = " . $organization_id . "
+                                            AND t2.organization_id = " . $organization_id . "
+                                            ");
+
+                if (count($duplicatedRoleTypes) > 0) {
+
+                    foreach ($duplicatedRoleTypes as $duplicatedRoleType) {
+
+                        $allDuplicatedRoleTypes[] = $duplicatedRoleType->id;
+
+                        $originalRoleType = DB::select("SELECT id, name
+                                                        FROM organization_role_types
+                                                        WHERE organization_id = " . $organization_id . "
+                                                        AND name = '" . $duplicatedRoleType->name . "'
+                                                        ORDER BY id ASC limit 1
+                                                    ");
+
+                        // remove or assign user role to original role id
+                        $userRoles = DB::table('organization_user_roles')
+                                        ->where('organization_role_type_id', $duplicatedRoleType->id)
+                                        ->get();
+
+                        if (count($userRoles) > 0) {
+
+                            foreach ($userRoles as $userRole) {
+
+                                DB::delete("DELETE FROM organization_user_roles
+                                        WHERE organization_role_type_id IN(
+                                                                        " . $duplicatedRoleType->id . " ,
+                                                                        " . $originalRoleType[0]->id . "
+                                                                    )
+                                        AND organization_id = " . $organization_id . "
+                                    ");
+
+                                DB::table("organization_user_roles")->insertOrIgnore(
+                                    [
+                                        'organization_id' => $organization_id,
+                                        'user_id' => $userRole->user_id,
+                                        'organization_role_type_id' => $originalRoleType[0]->id,
+                                        'created_at' => now(),
+                                        'updated_at' => now()
+                                    ]
+                                );
+                            }
+                        }
+
+                        // remove or assign role permissions to original role id
+                        $rolePermissions = DB::table('organization_role_permissions')
+                            ->where('organization_role_type_id', $duplicatedRoleType->id)
+                            ->get();
+
+                        if (count($rolePermissions) > 0) {
+
+                            foreach ($rolePermissions as $rolePermission) {
+
+                                DB::delete("DELETE FROM organization_role_permissions
+                                        WHERE organization_role_type_id IN(
+                                                                        " . $duplicatedRoleType->id . " ,
+                                                                        " . $originalRoleType[0]->id . "
+                                                                    )
+                                    ");
+
+                                DB::table("organization_role_permissions")->insertOrIgnore(
+                                    [
+                                        'organization_permission_type_id' => $rolePermission->organization_permission_type_id,
+                                        'organization_role_type_id' => $originalRoleType[0]->id,
+                                        'created_at' => now(),
+                                        'updated_at' => now()
+                                    ]
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (count($allDuplicatedRoleTypes) > 0) {
+                DB::delete("DELETE FROM organization_role_types WHERE id IN(" . implode(",", $allDuplicatedRoleTypes) . ") ");
+            }
+
+            // apply unique checks on name and organization_id to avoid duplications
+            Schema::table('organization_role_types', function (Blueprint $table) {
+                $table->unique(['name', 'organization_id']);
+            });
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('organization_role_types', function (Blueprint $table) {
+            $table->dropUnique(['name', 'organization_id']);
+        });
+    }
+}

--- a/database/migrations/2022_05_20_564513_create_composite_unique_index_on_organization_role_types_table.php
+++ b/database/migrations/2022_05_20_564513_create_composite_unique_index_on_organization_role_types_table.php
@@ -54,13 +54,12 @@ class CreateCompositeUniqueIndexOnOrganizationRoleTypesTable extends Migration
 
                                 DB::delete("DELETE FROM organization_user_roles
                                         WHERE organization_role_type_id IN(
-                                                                        " . $duplicatedRoleType->id . " ,
-                                                                        " . $originalRoleType[0]->id . "
+                                                                        " . $duplicatedRoleType->id . "
                                                                     )
                                         AND organization_id = " . $organization_id . "
                                     ");
 
-                                DB::table("organization_user_roles")->insertOrIgnore(
+                                $res = DB::table("organization_user_roles")->insertOrIgnore(
                                     [
                                         'organization_id' => $organization_id,
                                         'user_id' => $userRole->user_id,
@@ -83,8 +82,7 @@ class CreateCompositeUniqueIndexOnOrganizationRoleTypesTable extends Migration
 
                                 DB::delete("DELETE FROM organization_role_permissions
                                         WHERE organization_role_type_id IN(
-                                                                        " . $duplicatedRoleType->id . " ,
-                                                                        " . $originalRoleType[0]->id . "
+                                                                        " . $duplicatedRoleType->id . "
                                                                     )
                                     ");
 


### PR DESCRIPTION
1- check if there are duplicated role types that exist.
2- If yes, get all duplicated roles and delete existing and assign their associations to original role type IDs.
3- Remove all duplicated records once associations are deleted successfully.
4- Applied unique checks on role type name and organization_id in the database.