### PR TITLE
managed demo activity and video IDs for newly created organziation

### DIFF
--- a/app/Http/Controllers/Api/V1/SuborganizationController.php
+++ b/app/Http/Controllers/Api/V1/SuborganizationController.php
@@ -783,8 +783,7 @@ class SuborganizationController extends Controller
      */
     public function updateRole(SuborganizationUpdateRole $request, Organization $suborganization)
     {
-        // $this->authorize('updateRole', $suborganization);
-        //  have disable temporaily until frontend stuff is fully completed.
+        $this->authorize('updateRole', $suborganization);
         $data = $request->validated();
 
         $role = $suborganization->roles->where("id", $data['role_id']);

--- a/app/Repositories/Organization/OrganizationRepository.php
+++ b/app/Repositories/Organization/OrganizationRepository.php
@@ -953,6 +953,8 @@ class OrganizationRepository extends BaseRepository implements OrganizationRepos
                 'image' => $parentActivityLayout->image,
                 'created_at' => now(),
                 'organization_id' => $organization_id,
+                'demo_activity_id' => $parentActivityLayout->demo_activity_id,
+                'demo_video_id' => $parentActivityLayout->demo_video_id,
             ];
 
             ActivityLayout::insertOrIgnore($activityLayout);

--- a/database/migrations/2022_06_22_100000_delete_questionnaire_from_layouts_table.php
+++ b/database/migrations/2022_06_22_100000_delete_questionnaire_from_layouts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class DeleteQuestionnaireFromLayoutsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        \Artisan::call('db:seed', [
+            '--class' => DeleteQuestionnaireFromLayoutsSeeder::class,
+            '--force' => true
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+}

--- a/database/migrations/2022_06_22_300000_assign_default_admin_role_permissions_to_suborganization_admins.php
+++ b/database/migrations/2022_06_22_300000_assign_default_admin_role_permissions_to_suborganization_admins.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class AssignDefaultAdminRolePermissionsToSuborganizationAdmins extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        \Artisan::call('db:seed', [
+            '--class' => AssignDefaultAdminRolePermissionsToSuborganizationsAdminsSeeder::class,
+            '--force' => true
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+}

--- a/database/seeds/AssignDefaultAdminRolePermissionsToSuborganizationsAdminsSeeder.php
+++ b/database/seeds/AssignDefaultAdminRolePermissionsToSuborganizationsAdminsSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\OrganizationRoleType;
+use Illuminate\Database\Seeder;
+
+class AssignDefaultAdminRolePermissionsToSuborganizationsAdminsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $defaultAdminPermissions = DB::table('organization_role_permissions')
+                                        ->where('organization_role_type_id', 1)
+                                        ->pluck('organization_permission_type_id')
+                                        ->toArray();
+
+        $allAdminRoles = DB::table('organization_role_types')
+                            ->where('name', 'admin')
+                            ->where('id', '<>', 1)
+                            ->pluck('id')
+                            ->toArray();
+
+        if (count($defaultAdminPermissions) > 0 && count($allAdminRoles) > 0) {
+
+            foreach ($allAdminRoles as $roleId) {
+                $role = OrganizationRoleType::find($roleId);
+                if ($role) {
+                    $role->permissions()->sync($defaultAdminPermissions);
+                }
+            }
+
+        }
+    }
+}

--- a/database/seeds/DeleteQuestionnaireFromLayoutsSeeder.php
+++ b/database/seeds/DeleteQuestionnaireFromLayoutsSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class DeleteQuestionnaireFromLayoutsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::delete("DELETE FROM activity_layouts WHERE title = 'Questionnaire' ");
+    }
+}


### PR DESCRIPTION
- Managed demo activity and video IDs for the newly created organization.
- Assigned default admin permissions to all other organization admins.
- Deleted "Questionnaire" activity layout from layouts table.
- Removed commented update role policy that was commented for testing purposes.