### PR TITLE
CUR-3908: Backend: Library Preference API Work

### DIFF
--- a/app/Http/Requests/V1/IndependentActivityEditRequest.php
+++ b/app/Http/Requests/V1/IndependentActivityEditRequest.php
@@ -31,7 +31,7 @@ class IndependentActivityEditRequest extends FormRequest
             'order' => 'integer|max:2147483647',
             'shared' => 'boolean',
             'h5p_content_id' => 'integer',
-            'data' => 'required',
+            'data' => 'nullable',
             'thumb_url' => 'string',
             'subject_id' => 'array',
             'subject_id.*' => 'integer|distinct|exists:subjects,id,deleted_at,NULL',


### PR DESCRIPTION
Resolved issue with updating independent activity library preference, made "data" param "nullable".