### PR TITLE
[CUR-3967] Ignore password for existing user to assign another organization

### DIFF
--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -762,8 +762,7 @@ class UserController extends Controller
      *
      * Get a list of the users exported project
      *
-     * @queryParam size Limit for getting the paginated records, Default 25. Example: 25
-     * @queryParam days_limit days Limit for getting the exported project records, Default 10. Example: ?days_limit=5
+     * @queryParam suborganization id of an organization. Example: 1
      *
      * @responseFile responses/notifications/export-notifications.json
      *
@@ -773,7 +772,6 @@ class UserController extends Controller
      */
     public function exportProjectList(Request $request, Organization $suborganization)
     {
-
         return ExportedProjectsResource::collection($this->userRepository->getUsersExportProjectList($request->all(), $suborganization), 200);
     }
 
@@ -783,8 +781,7 @@ class UserController extends Controller
      *
      * Get a list of the users exported project
      *
-     * @queryParam size Limit for getting the paginated records, Default 25. Example: 25
-     * @queryParam days_limit days Limit for getting the exported project records, Default 10. Example: ?days_limit=5
+     * @queryParam suborganization id of an organization. Example: 1
      *
      * @responseFile responses/notifications/independent-activity-export-notifications.json
      *

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -744,8 +744,8 @@ class UserController extends Controller
      *
      * Returns the paginated response of the users with basic reporting.
      *
-     * @queryParam size Limit for getting the paginated records, Default 25. Example: 25
-     * @queryParam query for getting the search records by name and email. Example: Test
+     * @bodyParam size Limit for getting the paginated records, Default 25. Example: 25
+     * @bodyParam query for getting the search records by name and email. Example: Test
      *
      * @responseFile responses/admin/user/users_report.json
      *

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -762,7 +762,9 @@ class UserController extends Controller
      *
      * Get a list of the users exported project
      *
-     * @queryParam suborganization id of an organization. Example: 1
+     * @urlParam suborganization id of an organization. Example: 1
+     * @bodyParam size Limit for getting the paginated records, Default 25. Example: 25
+     * @bodyParam days_limit days Limit for getting the exported project records, Default 10. Example: ?days_limit=5
      *
      * @responseFile responses/notifications/export-notifications.json
      *
@@ -772,6 +774,7 @@ class UserController extends Controller
      */
     public function exportProjectList(Request $request, Organization $suborganization)
     {
+
         return ExportedProjectsResource::collection($this->userRepository->getUsersExportProjectList($request->all(), $suborganization), 200);
     }
 
@@ -781,7 +784,9 @@ class UserController extends Controller
      *
      * Get a list of the users exported project
      *
-     * @queryParam suborganization id of an organization. Example: 1
+     * @urlParam suborganization id of an organization. Example: 1
+     * @bodyParam size Limit for getting the paginated records, Default 25. Example: 25
+     * @bodyParam days_limit days Limit for getting the exported project records, Default 10. Example: ?days_limit=5
      *
      * @responseFile responses/notifications/independent-activity-export-notifications.json
      *

--- a/app/Http/Requests/V1/SuborganizationAddNewUser.php
+++ b/app/Http/Requests/V1/SuborganizationAddNewUser.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests\V1;
 
 use App\Rules\StrongPassword;
+use App\User;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class SuborganizationAddNewUser extends FormRequest
 {
@@ -24,12 +26,19 @@ class SuborganizationAddNewUser extends FormRequest
      */
     public function rules()
     {
+        $email = request('email');
         return [
             'first_name' => 'required|string|max:255',
             'last_name' => 'string|max:255',
             'email' => 'required|email|max:255',
             'job_title' => 'nullable|string|max:255',
-            'password' => ['required', 'string', new StrongPassword],
+            'password' => [
+                Rule::requiredIf( function () use ($email){
+                    return User::where('email', $email)->exists() === FALSE;
+                }),
+                'string',
+                new StrongPassword
+            ],
             'role_id' => 'required|integer|exists:organization_role_types,id',
             'organization_name' => 'string',
             'organization_type' => 'string',


### PR DESCRIPTION
If user email is already a part of any other organization and we want to add any new org, the password field will be now optional.