### PR TITLE
CUR-3971: Explore Library: Search results disappear when entering words that are not related to results in the "Does not contain" text box

### DIFF
--- a/app/Repositories/IndependentActivity/IndependentActivityRepository.php
+++ b/app/Repositories/IndependentActivity/IndependentActivityRepository.php
@@ -236,8 +236,7 @@ class IndependentActivityRepository extends BaseRepository implements Independen
         }
 
         if (isset($data['negativeQuery']) && !empty($data['negativeQuery'])) {
-            $queryWhere[] = "name NOT LIKE '%" . $data['negativeQuery'] . "%'";
-            $queryWhere[] = "description NOT LIKE '%" . $data['negativeQuery'] . "%'";
+            $queryWhere[] = "(name NOT LIKE '%" . $data['negativeQuery'] . "%' OR description NOT LIKE '%" . $data['negativeQuery'] . "%')";
         }
 
         if (isset($data['from']) && !empty($data['from'])) {


### PR DESCRIPTION
Resolved issue with independent search using negative query.