### PR TITLE
CUR-3997: Independent Activity Permissions Seeder

### DIFF
--- a/database/migrations/2022_08_17_122428_run_independent_activity_view_edit_permissions_seeder.php
+++ b/database/migrations/2022_08_17_122428_run_independent_activity_view_edit_permissions_seeder.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class RunIndependentActivityViewEditPermissionsSeeder extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        \Artisan::call('db:seed', [
+            '--class' => IndependentActivityPermissionsViewEditSeeder::class,
+            '--force' => true
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/seeds/IndependentActivityPermissionsViewEditSeeder.php
+++ b/database/seeds/IndependentActivityPermissionsViewEditSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class IndependentActivityPermissionsViewEditSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $defaultPermissions = [
+            'independent-activity:view-author', 
+            'independent-activity:edit-author'
+        ];
+
+        $viewEditPermissions = DB::table('organization_permission_types')
+                                                        ->select('id')
+                                                        ->whereIn('name', $defaultPermissions)
+                                                        ->get();
+
+        $organizationRoleTypes = DB::table('organization_role_types')
+                                    ->select('id')
+                                    ->get();
+
+        return DB::transaction(function () use ($viewEditPermissions, $organizationRoleTypes) {
+            foreach ($viewEditPermissions as $viewEditPermission) {
+                foreach ($organizationRoleTypes as $organizationRoleType) {
+                    DB::table('organization_role_permissions')->insertOrIgnore([
+                        'organization_role_type_id' => $organizationRoleType->id,
+                        'organization_permission_type_id' => $viewEditPermission->id,
+                        'created_at' => 'NOW()',
+                        'updated_at' => 'NOW()'
+                    ]);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Added seeder to assign view, edit permissions for independent activities for all user roles.