### PR TITLE
CUR-4133: Implement 'independent' activities data can be segregated from 'activities' data

### DIFF
--- a/database/migrations/2022_10_06_062631_create_outcome_data_view.php
+++ b/database/migrations/2022_10_06_062631_create_outcome_data_view.php
@@ -13,9 +13,8 @@ class CreateOutcomeDataView extends Migration
      */
     public function up()
     {
-        DB::statement("CREATE OR REPLACE VIEW outcome_data
- AS
- SELECT sq1.user_id,
+        DB::statement("CREATE OR REPLACE VIEW public.outcome_data
+AS SELECT sq1.user_id,
     sq1.class_id,
     sq1.project_id,
     lsd.project_name,
@@ -40,7 +39,7 @@ class CreateOutcomeDataView extends Migration
     lsd.glass_alternate_course_id,
     lsd.course_name AS grade_level,
     sq1.datetime
-   FROM ( SELECT lrs_statements_data.actor_id AS user_id,
+    FROM ( SELECT lrs_statements_data.actor_id AS user_id,
             lrs_statements_data.class_id,
             lrs_statements_data.project_id,
             lrs_statements_data.playlist_id,
@@ -49,13 +48,13 @@ class CreateOutcomeDataView extends Migration
             lrs_statements_data.chapter_name,
             replace(lrs_statements_data.question, '  '::text, ' '::text) AS question,
             max(lrs_statements_data.datetime) AS datetime
-           FROM lrs_statements_data
-          WHERE lrs_statements_data.question IS NOT NULL AND lrs_statements_data.verb::text <> 'submitted-curriki'::text
-          GROUP BY lrs_statements_data.actor_id, lrs_statements_data.class_id, lrs_statements_data.project_id, lrs_statements_data.playlist_id, lrs_statements_data.assignment_id, lrs_statements_data.submission_id, lrs_statements_data.chapter_name, (replace(lrs_statements_data.question, '  '::text, ' '::text))) sq1
-     LEFT JOIN lrs_statements_data lsd ON sq1.user_id::text = lsd.actor_id::text AND sq1.class_id = lsd.class_id AND sq1.project_id::text = lsd.project_id::text AND sq1.playlist_id::text = lsd.playlist_id::text AND sq1.assignment_id::text = lsd.assignment_id::text AND sq1.submission_id::text = lsd.submission_id::text AND sq1.chapter_name::text = lsd.chapter_name::text AND replace(sq1.question, '  '::text, ' '::text) = replace(lsd.question, '  '::text, ' '::text) AND sq1.datetime = lsd.datetime
-     LEFT JOIN lrs_metadata lm ON lsd.assignment_id::text = lm.activity_id::text AND lsd.chapter_name::text = lm.chapter_name::text
+            FROM lrs_statements_data
+            WHERE lrs_statements_data.question IS NOT NULL AND lrs_statements_data.answer IS NOT NULL AND (lrs_statements_data.verb::text = ANY (ARRAY['answered'::text, 'interacted'::text, 'completed'::text]))
+            GROUP BY lrs_statements_data.actor_id, lrs_statements_data.class_id, lrs_statements_data.project_id, lrs_statements_data.playlist_id, lrs_statements_data.assignment_id, lrs_statements_data.submission_id, lrs_statements_data.chapter_name, (replace(lrs_statements_data.question, '  '::text, ' '::text))) sq1
+        LEFT JOIN lrs_statements_data lsd ON sq1.user_id::text = lsd.actor_id::text AND sq1.class_id = lsd.class_id AND sq1.assignment_id::text = lsd.assignment_id::text AND sq1.submission_id::text = lsd.submission_id::text AND sq1.chapter_name::text = lsd.chapter_name::text AND replace(sq1.question, '  '::text, ' '::text) = replace(lsd.question, '  '::text, ' '::text) AND sq1.datetime = lsd.datetime
+        LEFT JOIN lrs_metadata lm ON lsd.assignment_id::text = lm.activity_id::text AND lsd.chapter_name::text = lm.chapter_name::text
 UNION ALL
- SELECT sq1.user_id,
+    SELECT sq1.user_id,
     sq1.class_id,
     lsd.project_id,
     sq1.project_name,
@@ -80,18 +79,18 @@ UNION ALL
     lsd.glass_alternate_course_id,
     lsd.course_name AS grade_level,
     sq1.datetime
-   FROM ( SELECT lrs_statements_data.actor_id AS user_id,
+    FROM ( SELECT lrs_statements_data.actor_id AS user_id,
             lrs_statements_data.class_id,
             lrs_statements_data.project_name,
             lrs_statements_data.playlist_name,
             lrs_statements_data.assignment_name,
             lrs_statements_data.submission_id,
             max(lrs_statements_data.datetime) AS datetime
-           FROM lrs_statements_data
-          WHERE lrs_statements_data.verb::text = 'submitted-curriki'::text
-          GROUP BY lrs_statements_data.actor_id, lrs_statements_data.class_id, lrs_statements_data.project_name, lrs_statements_data.playlist_name, lrs_statements_data.assignment_name, lrs_statements_data.submission_id) sq1
-     LEFT JOIN lrs_statements_data lsd ON sq1.user_id::text = lsd.actor_id::text AND sq1.class_id = lsd.class_id AND sq1.project_name::text = lsd.project_name::text AND sq1.playlist_name::text = lsd.playlist_name::text AND sq1.assignment_name::text = lsd.assignment_name::text AND sq1.submission_id::text = lsd.submission_id::text AND sq1.datetime = lsd.datetime
-  WHERE lsd.verb::text = 'submitted-curriki'::text");
+            FROM lrs_statements_data
+            WHERE lrs_statements_data.verb::text = 'submitted-curriki'::text
+            GROUP BY lrs_statements_data.actor_id, lrs_statements_data.class_id, lrs_statements_data.project_name, lrs_statements_data.playlist_name, lrs_statements_data.assignment_name, lrs_statements_data.submission_id) sq1
+        LEFT JOIN lrs_statements_data lsd ON sq1.user_id::text = lsd.actor_id::text AND sq1.class_id = lsd.class_id AND sq1.assignment_name::text = lsd.assignment_name::text AND sq1.submission_id::text = lsd.submission_id::text AND sq1.datetime = lsd.datetime
+    WHERE lsd.verb::text = 'submitted-curriki'::text");
     }
 
     /**


### PR DESCRIPTION
Integrated the script for outcome_data view in migration.