### PR TITLE
CUR-4133: Implement 'independent' activities data can be segregated from 'activities' data

### DIFF
--- a/app/Console/Commands/MoveIndependentActivitiesToActivities.php
+++ b/app/Console/Commands/MoveIndependentActivitiesToActivities.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Repositories\IndependentActivity\IndependentActivityRepositoryInterface;
+
+class MoveIndependentActivitiesToActivities extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'move:independent-activities';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Move existing independent activities to activities';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(
+        IndependentActivityRepositoryInterface $independentActivityRepository
+    )
+    {
+        return $independentActivityRepository->copyToActivity();
+    }
+}


### PR DESCRIPTION
Created migration for moving independent activities data, H5P and thumb images and to activities.