### PR TITLE
CUR-4454: Preview-Share: P/P/A and Ind activities still appears on share link page when turning the "Disable Sharing" button with "Library Preferences: with all option"

### DIFF
--- a/app/Http/Controllers/Api/V1/ActivityController.php
+++ b/app/Http/Controllers/Api/V1/ActivityController.php
@@ -730,7 +730,7 @@ class ActivityController extends Controller
     public function getH5pResourceSettingsShared(Activity $activity)
     {
         // 3 is for indexing approved - see Project Model @indexing property
-        if ($activity->shared || ($activity->playlist->project->indexing === (int)config('constants.indexing-approved'))) {
+        if ($activity->shared) {
             $h5p = App::make('LaravelH5p');
             $core = $h5p::$core;
             $settings = $h5p::get_editor($content = null, 'preview');

--- a/app/Http/Controllers/Api/V1/IndependentActivityController.php
+++ b/app/Http/Controllers/Api/V1/IndependentActivityController.php
@@ -793,7 +793,7 @@ class IndependentActivityController extends Controller
     public function getH5pResourceSettingsShared(IndependentActivity $independent_activity)
     {
         // 3 is for indexing approved - see IndependentActivity Model @indexing property
-        if ($independent_activity->shared || ($independent_activity->indexing === (int)config('constants.indexing-approved'))) {
+        if ($independent_activity->shared) {
             $h5p = App::make('LaravelH5p');
             $core = $h5p::$core;
             $settings = $h5p::get_editor();


### PR DESCRIPTION
Disabled sharing on library preferences set to all.