### PR TITLE
CUR-4454  Preview-Share: P/P/A and Ind activities still appears on share link page when turning the "Disable Sharing" button with "Library Preferences: with all option"

### DIFF
--- a/app/Http/Controllers/Api/V1/PlaylistController.php
+++ b/app/Http/Controllers/Api/V1/PlaylistController.php
@@ -497,7 +497,7 @@ class PlaylistController extends Controller
     public function loadSharedPlaylist(Project $project, Playlist $playlist)
     {
         // 3 is for indexing approved - see Project Model @indexing property
-        if ($project->shared || ($project->indexing === Config::get('constants.indexing-approved'))) {
+        if ($project->shared) {
             if($playlist->shared){
                 return response([
                     'playlist' => new PlaylistResource($this->playlistRepository->loadSharedPlaylist($playlist)),

--- a/app/Http/Controllers/Api/V1/ProjectController.php
+++ b/app/Http/Controllers/Api/V1/ProjectController.php
@@ -391,7 +391,7 @@ class ProjectController extends Controller
     public function loadShared(Project $project)
     {
         // 3 is for indexing approved - see Project Model @indexing property
-        if ($project->shared || ($project->indexing === 3)) {
+        if ($project->shared) {
             return response([
                 'project' => $this->projectRepository->getProjectForPreview($project),
             ], 200);


### PR DESCRIPTION
Disabled project and playlist sharing on library preferences set to all.