### PR TITLE
xAPI extraction was failing in microsoft teams because class ids ther…

### DIFF
--- a/app/Services/LearnerRecordStoreService.php
+++ b/app/Services/LearnerRecordStoreService.php
@@ -691,7 +691,7 @@ class LearnerRecordStoreService implements LearnerRecordStoreServiceInterface
         ];
         if (!empty($other)) {
             $attempt_pattern = "/\/activity\/(\d*)\/submission\/(.*)\/(\d*)/";
-            $class_pattern = "/\/(gclass|lti)\/(\d*)/";
+            $class_pattern = "/\/(gclass|lti)\/(.*)/";
             $matches = [];
             $class_matches = [];
             // Other regexes saved for later.


### PR DESCRIPTION
…e are alphanumeric